### PR TITLE
Stop the config-tree fixture leaking into the rest of the session

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+# Prepare a Claude Code on the web session to actually run this project.
+#
+# Two things make a bare container unable to run the test suite:
+#
+#   1. The default python3 in the image is 3.11, and requirements.txt pins
+#      scipy>=1.18, which ships no 3.11 wheels. `pip install -r requirements.txt`
+#      fails outright. setup.py already declares python_requires=">=3.12"; this
+#      builds the venv with 3.12 to match it and CI.
+#
+#   2. CI installs torch from https://download.pytorch.org/whl/cpu. That host is
+#      not reachable through the web sandbox's egress proxy, so this hook lets
+#      torch resolve from PyPI instead. The only difference is the bundled
+#      nvidia-* runtime packages, which nothing here uses on CPU.
+#
+# Idempotent: the venv is reused across sessions, and pip re-runs are no-ops
+# once the container state is cached.
+set -euo pipefail
+
+# Local checkouts already have a working environment; this is remote-only.
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+REPO="${CLAUDE_PROJECT_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
+VENV="$REPO/.venv"   # already covered by .gitignore
+
+cd "$REPO"
+
+# 3.12 specifically: 3.13 is not what CI tests and Ray 2.56.1 does not ship
+# wheels for every 3.13 dependency combination this project pins.
+PY=""
+for candidate in python3.12 python3; do
+  if command -v "$candidate" >/dev/null 2>&1 &&
+     "$candidate" -c 'import sys; sys.exit(0 if sys.version_info[:2] == (3, 12) else 1)' 2>/dev/null; then
+    PY="$candidate"
+    break
+  fi
+done
+
+if [ -z "$PY" ]; then
+  echo "session-start: no Python 3.12 interpreter found; this project requires it" >&2
+  echo "session-start: found python3 = $(python3 --version 2>&1 || echo none)" >&2
+  exit 1
+fi
+
+if [ ! -x "$VENV/bin/python" ]; then
+  echo "session-start: creating $VENV with $($PY --version)"
+  "$PY" -m venv "$VENV"
+fi
+
+echo "session-start: installing dependencies"
+# setuptools/wheel explicitly rather than relying on `pip install -e .` to pull
+# a build backend in: setup.py is a legacy (non-PEP-517-declaring) build, so the
+# backend needs to be present in the venv rather than assumed.
+#
+# Unrelated cosmetic note: `python3.12 -m venv` above prints a _distutils_hack
+# traceback on first run. That comes from the *system* interpreter's
+# /usr/lib/python3/dist-packages/distutils-precedence.pth while it builds the
+# venv - not from the venv, which runs clean. It is harmless and first-run only.
+"$VENV/bin/python" -m pip install --quiet --upgrade pip setuptools wheel
+"$VENV/bin/python" -m pip install --quiet -r requirements.txt
+"$VENV/bin/python" -m pip install --quiet -e ".[dev]"
+
+# Put the venv ahead of the system interpreter for the rest of the session, so
+# `python`, `pip` and `pytest` are the project's without needing the full path.
+if [ -n "${CLAUDE_ENV_FILE:-}" ]; then
+  {
+    echo "export VIRTUAL_ENV=$VENV"
+    echo "export PATH=$VENV/bin:\$PATH"
+  } >> "$CLAUDE_ENV_FILE"
+fi
+
+echo "session-start: ready - $("$VENV/bin/python" --version)"

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/config/train_config.json
+++ b/config/train_config.json
@@ -53,7 +53,7 @@
   },
 
   "league_self_play": {
-    "_note": "nav_tolerance is the absolute cash tolerance for the episode-end NAV conservation check: the ledger is Decimal end to end, so conservation holds to the cent and the tolerance only absorbs the float() round trip through the info dict. Widen it only for a change that legitimately removes cash from the system, such as fees. strict_nav_check true raises on a violation, because a broken conservation invariant means the ledger is corrupt and everything trained after it is meaningless; false downgrades it to an ERROR log plus the nav_conservation_error metric, for a run that would rather keep going and be inspected afterwards.",
+    "_note": "nav_tolerance is the absolute cash tolerance for the episode-end NAV conservation check. The ledger is Decimal end to end and the check now parses info['NAV'] back with Decimal rather than float, so conservation is exact by construction and the expected error is 0, not merely small. The tolerance is therefore headroom for a change that legitimately removes cash from the system, such as fees - it is not absorbing arithmetic noise. Widen it for such a change; it can be set to 0 for a run that wants the invariant enforced exactly. strict_nav_check true raises on a violation, because a broken conservation invariant means the ledger is corrupt and everything trained after it is meaningless; false downgrades it to an ERROR log plus the nav_conservation_error metric, for a run that would rather keep going and be inspected afterwards.",
 
     "std_dev_multiplier": 0.1,
     "max_champions": 8,

--- a/doc/07_reward_function.md
+++ b/doc/07_reward_function.md
@@ -239,8 +239,11 @@ During training, monitor each term's contribution to total reward variance. A he
 | Penalties | ~20% |
 | Bonuses | ~10% |
 
-None of the five terms is currently logged individually, so this is not measurable without adding
-instrumentation — see [11_logging_and_observability.md](11_logging_and_observability.md) §2.4.
+All five terms are now logged individually, in `info["reward_terms"]`, as signed contributions
+that sum exactly to the reward — see
+[11_logging_and_observability.md](11_logging_and_observability.md) §1.7. The split above is
+therefore measurable from the per-step record; computing the variance share per episode is a
+reduction over that record, not a further instrumentation problem.
 
 ### 6.5 Make coefficients scale-invariant
 

--- a/doc/10_testing.md
+++ b/doc/10_testing.md
@@ -65,7 +65,7 @@ Counts re-measured with `--collect-only`; the earlier `90` predated the config a
 | `test_observation_history.py` | 3 | Temporal stacking |
 | `test_obs_market_features.py` | 17 | `log_mid`, `log1p_spread_ticks` |
 | `test_reward_logic.py` | 4 | Reward formula components |
-| `test_nav_callback.py` | 6 | Episode-end NAV conservation check: raises, tolerance, metric, strict off |
+| `test_nav_callback.py` | 8 | Episode-end NAV conservation check: raises, tolerance, metric, strict off, exactness at a scale `float` cannot resolve |
 | `test_logging_setup.py` | 10 | Level resolution and export, handler setup, no `print` in `envs/` or `train/` |
 | `test_probabilistic_mapping.py` | 1 | League matchmaking distribution |
 | `test_config_loading.py` | 15 | `train_config.json` → `TrainConfig` → env |
@@ -75,7 +75,8 @@ Counts re-measured with `--collect-only`; the earlier `90` predated the config a
 | `test_checkpointing.py` | 50 | Checkpoint retention, restore selection, league state across a save |
 | `test_champion_trigger.py` | 6 | League statistics with modules that played no episodes |
 | `test_progress_log.py` | 19 | `progress.jsonl` writer, numpy/NaN handling, `vf_explained_var` extraction |
-| **unit total** | **253** | |
+| `test_info_dict.py` | 18 | Per-step `info`: back-compat, reward terms summing exactly, live counters, spread, JSON |
+| **unit total** | **273** | |
 | `integration/test_league_wiring.py` | 13 | RLlib wiring, 3 topologies |
 | `integration/test_checkpoint_roundtrip.py` | 7 | One real save and restore: weights, league, iteration, optimizer |
 | `integration/test_progress_and_vf.py` | 6 | A real short run's `progress.jsonl`; `vf_explained_var` reported and finite (1 xfail pins S1-1) |

--- a/doc/10_testing.md
+++ b/doc/10_testing.md
@@ -17,14 +17,15 @@ of `self.assertX(...)`, and pytest's built-in xunit-style hooks (`setup_method` 
 `unittest`-based suite; see [17_changelog.md](17_changelog.md).
 
 ```bash
-# everything (254 tests: 234 unit + 20 integration)
+# everything (279 tests: 253 unit + 26 integration)
 python -m pytest gym_continuousDoubleAuction/test -q
 
 # unit tests only, skipping the slow RLlib ones
 python -m pytest gym_continuousDoubleAuction/test -q \
     --ignore=gym_continuousDoubleAuction/test/integration
 
-# RLlib wiring and the real save/restore (20 tests, builds real Algorithms)
+# RLlib wiring, the real save/restore, and the progress log (26 tests,
+# builds real Algorithms; one is an xfail pinning S1-1)
 python -m pytest gym_continuousDoubleAuction/test/integration -q
 
 # a single file
@@ -45,7 +46,7 @@ collects `TestCase` subclasses, and none of these classes are one any more. **[v
 `python -m unittest discover -s gym_continuousDoubleAuction/test -p "test_*.py"` reports
 `Ran 0 tests`.
 
-**[verified]** — `254 passed`.
+**[verified]** — `278 passed, 1 xfailed` (the xfail pins S1-1; see §6.2.2).
 
 ### File inventory
 
@@ -73,10 +74,12 @@ Counts re-measured with `--collect-only`; the earlier `90` predated the config a
 | `test_runtime_profiles.py` | 23 | `runtime_profiles.json` → hardware sets, platform paths |
 | `test_checkpointing.py` | 50 | Checkpoint retention, restore selection, league state across a save |
 | `test_champion_trigger.py` | 6 | League statistics with modules that played no episodes |
-| **unit total** | **234** | |
+| `test_progress_log.py` | 19 | `progress.jsonl` writer, numpy/NaN handling, `vf_explained_var` extraction |
+| **unit total** | **253** | |
 | `integration/test_league_wiring.py` | 13 | RLlib wiring, 3 topologies |
 | `integration/test_checkpoint_roundtrip.py` | 7 | One real save and restore: weights, league, iteration, optimizer |
-| **integration total** | **20** | |
+| `integration/test_progress_and_vf.py` | 6 | A real short run's `progress.jsonl`; `vf_explained_var` reported and finite (1 xfail pins S1-1) |
+| **integration total** | **26** | |
 
 > **Stale references in older docs.** `test_orderbook.py`, `repro_orderbook_crossed_book.py`,
 > `test_OrderBook.py`, `test_cda_nsp.py` and `test_orderbook_double_delete_order.py` do not exist.
@@ -435,6 +438,32 @@ Two things this suite had to get right, and which are worth preserving in any ed
 Verified to fail for the right reason: flipping the restore to `is_restore=False` fails 5 of the
 7, the two survivors being the ones that do not depend on the restore.
 
+### 6.2.2 `integration/test_progress_and_vf.py` — 1 class, 6 tests (1 xfail)
+
+`test_progress_log.py` (§6.1) covers the `progress.jsonl` writer and the `vf_explained_var`
+extraction against a `FakeAlgo` whose results are hand-built, which leaves the assumption
+underneath both untested: that a *real* PPO iteration on this env produces a `learners` block
+containing that key, and that a real result dict survives the JSON round trip. A rename in RLlib
+would sail past every unit test and leave the run logging nothing. This trains a real PPO for
+three iterations (~15s) and reads the file back.
+
+| Test | What it pins |
+|---|---|
+| `test_one_line_per_iteration` | The file exists and `training_iteration` runs 1..N with no gaps |
+| `test_a_real_result_survives_the_json_round_trip` | The nested `env_runners` and `learners` blocks are still *in* the line, not merely that it parses |
+| `test_vf_explained_var_is_reported_for_every_trainable_module` | The key RLlib really emits, for exactly the modules in `policies_to_train` |
+| `test_the_metric_is_finite` | A NaN is a diverged value loss |
+| `test_the_critic_actually_explains_something` | **strict xfail** — `\|vf_explained_var\| >= 1e-3`. Fails today because S1-1 is open |
+| `test_the_file_carries_it_too` | The on-disk record, not just the returned result, has the metric for every iteration |
+
+The one thing worth preserving in any edit here is the assertion that is deliberately *absent*.
+`!= 0.0` is the obvious guard against a critic that never received a gradient, and it is worthless
+on this repository: a run reports values around 1e-5 — the S1-1 signature [17](17_changelog.md)
+§17.3 records as "0.0 to 1.8e-07" — and every one of them is nonzero, so it passes on a critic
+that is entirely dead. Floating-point noise is not evidence of learning. The strict xfail is what
+carries the real claim: when S1-1 is fixed it XPASSes and fails the build, and removing the marker
+at that point turns it into a live regression guard.
+
 ### 6.3 `test_runtime_profiles.py` — 23 tests
 
 Covers [`config/runtime_profiles.json`](../config/runtime_profiles.json) and
@@ -493,7 +522,7 @@ Honest accounting of what the suite does **not** cover.
 
 | Gap | Risk |
 |---|---|
-| **No learning-signal assertion** | Nothing checks `vf_explained_var`, `vf_loss` saturation, or that returns improve. This is exactly how the frozen critic (S1-1) went unnoticed — the integration suite is otherwise built precisely to catch silent degradation. |
+| **The learning-signal assertion is an xfail, not a guard** | `integration/test_progress_and_vf.py` now checks `vf_explained_var` is reported and finite, and pins the substantive threshold (`>= 1e-3`) as a strict xfail because S1-1 is open — so the suite records the frozen critic rather than catching it. Note what does *not* work here: asserting `!= 0.0` passes today on a critic sitting in the 1e-5 noise floor. `vf_loss` saturation and "returns improve" are still unchecked. |
 | **`test_accounting.py::test_insufficient_funds` is an empty `pass`** | The body is a 15-line comment debating what the behaviour *should* be, ending "Will implement based on observed behavior or re-read code carefully." A TODO shipped as a test. The behaviour it was meant to cover is in fact tested by `test_cash_check.py`. |
 | **No information-content tests for the observation** | The suite would pass unchanged with the varying-denominator stack, the zero-collision ambiguity and the dead tape loop all present — and all three are present ([05](05_observation_space.md) §7). |
 | **`test_shared_history_multi_agent_uniformity` encodes a defect as a requirement** | See §4.2. |

--- a/doc/10_testing.md
+++ b/doc/10_testing.md
@@ -17,7 +17,7 @@ of `self.assertX(...)`, and pytest's built-in xunit-style hooks (`setup_method` 
 `unittest`-based suite; see [17_changelog.md](17_changelog.md).
 
 ```bash
-# everything (279 tests: 253 unit + 26 integration)
+# everything (314 tests: 288 unit + 26 integration)
 python -m pytest gym_continuousDoubleAuction/test -q
 
 # unit tests only, skipping the slow RLlib ones
@@ -46,7 +46,7 @@ collects `TestCase` subclasses, and none of these classes are one any more. **[v
 `python -m unittest discover -s gym_continuousDoubleAuction/test -p "test_*.py"` reports
 `Ran 0 tests`.
 
-**[verified]** — `278 passed, 1 xfailed` (the xfail pins S1-1; see §6.2.2).
+**[verified]** — `313 passed, 1 xfailed` (the xfail pins S1-1; see §6.2.2).
 
 ### File inventory
 
@@ -76,7 +76,8 @@ Counts re-measured with `--collect-only`; the earlier `90` predated the config a
 | `test_champion_trigger.py` | 6 | League statistics with modules that played no episodes |
 | `test_progress_log.py` | 19 | `progress.jsonl` writer, numpy/NaN handling, `vf_explained_var` extraction |
 | `test_info_dict.py` | 18 | Per-step `info`: back-compat, reward terms summing exactly, live counters, spread, JSON |
-| **unit total** | **273** | |
+| `test_type_policy.py` | 15 | Decimal money/prices, int sizes, no field changing type mid-episode, book boundary |
+| **unit total** | **288** | |
 | `integration/test_league_wiring.py` | 13 | RLlib wiring, 3 topologies |
 | `integration/test_checkpoint_roundtrip.py` | 7 | One real save and restore: weights, league, iteration, optimizer |
 | `integration/test_progress_and_vf.py` | 6 | A real short run's `progress.jsonl`; `vf_explained_var` reported and finite (1 xfail pins S1-1) |

--- a/doc/11_logging_and_observability.md
+++ b/doc/11_logging_and_observability.md
@@ -185,6 +185,48 @@ Covered by `test_progress_log.py` (one line per iteration, appends across a rest
 survive as numbers, awkward values, and a write failure that must not stop the loop) and by
 `test/integration/test_progress_and_vf.py`, which trains a real PPO and reads the file back.
 
+### 1.7 Per-step `info` (account, market and reward decomposition)
+
+`Info_Helper.set_info` reported three fields — `reward`, `NAV`, `num_trades`. Everything else a
+step knew about itself was computed, consumed and dropped: the position, the drawdown the penalty
+had just been charged on, the spread, and the five reward components. §2.2–2.4 below were that
+gap; what follows is what closes it.
+
+**The original three are unchanged** — same names, same types, same order. `NAV` stays a *string*,
+the exact `str()` of a `Decimal`, because the conservation check parses it back with `Decimal`
+(§1.5) and `visualize_nav.py` with `float()`. §2.6 tracks that round trip as its own question and
+is not settled here.
+
+| Group | Fields |
+|---|---|
+| Account (§2.3) | `net_position`, `VWAP`, `cash`, `cash_on_hold`, `position_val`, `drawdown`, `max_nav`, `num_trades_step`, `num_passive_fills_step`, `order_step_placed` |
+| Market (§2.2) | `last_price`, `best_bid`, `best_ask`, `spread` |
+| Reward (§2.4) | `reward_terms`: `nav_term`, `order_penalty`, `trade_penalty`, `drawdown_penalty`, `passive_bonus` |
+| Action | `model_action` — as the model emitted it, before `set_actions` reshapes it for the book |
+
+Four decisions worth stating, because each could reasonably have gone the other way:
+
+* **The reward terms are signed contributions that sum to `reward`, and the sum *is* the reward.**
+  `set_reward` accumulates the dict rather than evaluating a second expression, so the logged
+  split cannot drift from the number the agent was trained on. The accumulation is a left-to-right
+  loop, deliberately **not** `sum()`: on Python 3.12+ the builtin applies Neumaier compensated
+  summation to floats, which disagrees with plain accumulation on ~44% of random inputs (~1e-13
+  relative). Instrumenting the reward must not change it.
+* **New numeric fields go out as plain numbers, not strings.** They are diagnostics, not
+  invariants — nothing reconstructs the ledger from them, and `float` is what the metrics stack
+  and `json` consume. `NAV` alone keeps the string treatment, for the reason above.
+* **`net_position` is reported as a float** even though `account.py` initialises it to `int` 0. The
+  account rebuilds it as a `Decimal` on the first fill, so the underlying type changes partway
+  through an episode; the reported field holds one type throughout.
+* **`spread` is `None`, not `0.0`, on a one-sided book.** The observation needs a finite sentinel
+  and uses `0.0`; a log does not, and `0.0` there would be indistinguishable from a book whose
+  touch is one tick wide — the ambiguity [15 S3-14](15_findings_and_recommendations.md) is about.
+
+Covered by `test_info_dict.py` (18 tests): back-compat of the original three, the terms summing
+exactly, penalties matching coefficient × counter, the counters being read *before*
+`set_step_outputs` zeroes them, `spread` on a one-sided book, and the whole dict surviving
+`json.dumps`.
+
 ---
 
 ## 2. What is not logged but should be
@@ -217,10 +259,11 @@ or aggregated into a metric worth alerting on.
 
 ### 2.2 Environment and market data
 
+`last_price` and the bid-ask spread are **done** — both are in the per-step `info` dict (§1.7),
+alongside `best_bid` and `best_ask`. What is still missing:
+
 | Missing | Why it matters |
 |---|---|
-| Last traded price per step | The central price signal; needed to reconstruct the price series |
-| Bid-ask spread | Key market-quality metric |
 | Order book depth per level | Liquidity analysis |
 | Market / limit / modify / cancel action counts per episode | Reveals strategy evolution |
 | Count of `category=0` (do-nothing) actions | **Directly detects the passivity collapse predicted by S1-3** |
@@ -228,22 +271,26 @@ or aggregated into a metric worth alerting on.
 
 ### 2.3 Agent and account state
 
-| Missing | Why it matters |
-|---|---|
-| Per-agent drawdown, current and max | The reward uses `max_nav − nav` but never logs it |
-| Per-agent `net_position` at episode end | Reveals held inventory risk |
-| Per-agent `VWAP` | Average fill quality |
-| Per-agent `cash_on_hold` | How much capital is locked in open orders |
-| `order_step_placed`, `num_passive_fills_step` | Reward sub-components computed, consumed, then zeroed |
-| Passive fill ratio | Distinguishes market-making from taking |
+**Done** — all of these are in the per-step `info` dict (§1.7): current `drawdown` and `max_nav`,
+`net_position` (every step, not only at episode end), `VWAP`, `cash`, `cash_on_hold`,
+`position_val`, and the three per-step counters `order_step_placed`, `num_passive_fills_step` and
+`num_trades_step`, read before `set_step_outputs` zeroes them.
+
+Passive fill ratio is not emitted as its own field: it is exactly
+`num_passive_fills_step / num_trades_step`, and both are now logged, so deriving it needs no
+further instrumentation. A field would only add a division-by-zero convention to argue about.
 
 ### 2.4 Reward decomposition
 
-None of the five terms is logged individually — `nav_term`, order penalty, trade penalty,
-drawdown penalty, passive bonus. The largest reward driver is invisible, and there is no way to
-detect over- or under-trading, risk-aversion learning, or market-making uptake from the logs. It
-also makes the tuning guidance in [07_reward_function.md](07_reward_function.md) §6.4
-unmeasurable without adding instrumentation first.
+**Done.** All five terms — `nav_term`, order penalty, trade penalty, drawdown penalty, passive
+bonus — are in `info["reward_terms"]` as signed contributions that sum exactly to `reward`
+(§1.7). The variance split in [07_reward_function.md](07_reward_function.md) §6.4 is measurable
+from the per-step record without further instrumentation, as is over- or under-trading,
+risk-aversion learning and market-making uptake.
+
+What remains is *aggregation*: the terms are per step and per agent, so a per-episode variance
+share is a reduction a consumer still has to perform. Doing that through `metrics_logger` is
+[15](15_findings_and_recommendations.md) Phase 4 item 15.
 
 ### 2.5 League and self-play state
 

--- a/doc/11_logging_and_observability.md
+++ b/doc/11_logging_and_observability.md
@@ -138,15 +138,64 @@ violation raises under the default, the metric is emitted before the raise, non-
 and continues, the tolerance admits what is inside it and not what is outside, and both knobs come
 from the config file.
 
+### 1.6 Per-iteration training history (`progress.jsonl`)
+
+`train()` calls `algo.train()` directly rather than through `tune.Tuner`, so nothing writes
+`progress.csv` or TensorBoard event files. Each iteration's result dict used to be summarised into
+one log line and dropped, which left a finished run with checkpoints, scrollback, and no queryable
+record of how it got there.
+
+Every iteration now appends one JSON object to `<log_base_dir>/progress.jsonl`:
+
+```python
+result = algo.train()
+_log_iteration(iteration, target, result, cfg)
+_append_progress(result, cfg)
+```
+
+* **The whole result dict**, not a chosen subset. The loss terms, KL, entropy, timers and learner
+  stats are all in there; deciding today which of them a future question needs is exactly the
+  mistake that produced this gap.
+* **`_json_safe` runs first.** RLlib results carry numpy scalars and arrays, occasional objects
+  with no JSON form, and NaNs. Numbers stay numbers (a bare `default=str` would write `"1.5"` and
+  make every reader parse it back), non-finite floats become `null` — `NaN` and `Infinity` are not
+  valid JSON — and anything left over is stringified.
+* **Opened and closed per iteration.** These runs normally end by being killed, so a buffer held
+  open for the run would lose the iterations it had already finished. Append mode also means a
+  resumed run extends its history rather than truncating it.
+* **Every failure is swallowed with a warning.** A full disk must not take down a run that is
+  otherwise training fine.
+* It sits beside `chkpt/` under `log_base_dir`, not with the per-episode pickles: one short line
+  per iteration belongs with the things that must survive a disconnect, which is why
+  `runtime_profiles.json` splits `results_root` from `episode_data_root` in the first place.
+
+Covered by `test_progress_log.py` (one line per iteration, appends across a restart, numbers
+survive as numbers, awkward values, and a write failure that must not stop the loop) and by
+`test/integration/test_progress_and_vf.py`, which trains a real PPO and reads the file back.
+
 ---
 
 ## 2. What is not logged but should be
 
 ### 2.1 Training metrics
 
+Done, and no longer on this list: **`vf_explained_var`** — the one metric that exposes the frozen
+critic (S1-1), and whose absence is why that defect survived. `_log_iteration` now prints it per
+trainable module on every iteration, read from `result["learners"][<module_id>]` and keyed on
+`trainable_policy_ids`, since only the modules in `policies_to_train` appear in that block.
+
+`test/integration/test_progress_and_vf.py` asserts in CI that a real run reports it, finite, for
+every trainable module. It deliberately does **not** assert `!= 0.0`: this repository currently
+reports values around 1e-5, so that assertion passes on a critic that is entirely dead. The
+substantive threshold (`>= 1e-3`) is there as a strict xfail that pins S1-1 as a known failure and
+becomes a live guard the moment it is fixed.
+
+Everything else on this list is *computed* by RLlib and reaches `progress.jsonl` (§1.6) as part of
+the full result dict. What is still missing is surfacing: none of it is in the iteration log line
+or aggregated into a metric worth alerting on.
+
 | Missing | Why it matters |
 |---|---|
-| **`vf_explained_var`** | The one metric that exposes the frozen critic (S1-1). Nothing surfaces it, which is why the defect survived. |
 | `vf_loss` vs `vf_loss_unclipped` | The saturation is invisible from `total_loss` alone |
 | Per-policy reward mean / min / max / std | Only league aggregates are logged; individual trends are invisible |
 | Policy win rate versus random and versus champion | The key signal for league-based training |
@@ -211,18 +260,20 @@ chosen for, and it makes the info dict awkward for RLlib metric aggregation.
 | Per-episode `.pkl` files grow without rotation or size cap | Disk fills over long runs; the flag is off/on, not bounded |
 | Episode `.pkl` files carry no timestamp or iteration metadata | Hard to correlate with training progress |
 | `pickle` format | Arbitrary code execution on load; prefer `npz` / `parquet` / `jsonl` |
-| No per-iteration training history on disk | `algo.train()` runs outside `tune.Tuner`, so nothing writes `progress.csv` or TensorBoard events; each result dict is logged in summary and dropped |
+| `progress.jsonl` grows without rotation | One line per iteration is small, but nothing bounds it across a long series of resumed runs |
 
-Logging itself is no longer in this table: output is levelled, attributable and switchable, and
-the `g_store` dead code is gone (§1.3, §1.4). What is still missing is a *machine-readable* record
-of training progress - see §4.
+Two things are no longer in this table. Logging itself: output is levelled, attributable and
+switchable, and the `g_store` dead code is gone (§1.3, §1.4). And the absence of a per-iteration
+training history: `progress.jsonl` is that machine-readable record (§1.6).
 
 ---
 
 ## 4. Recommended additions
 
-Done, and no longer on this list: `logging` in place of `print`, and raising on a NAV conservation
-violation with a `nav_conservation_error` metric.
+Done, and no longer on this list: `logging` in place of `print`; raising on a NAV conservation
+violation with a `nav_conservation_error` metric; writing each iteration's result dict to
+`progress.jsonl` (§1.6); and logging `vf_explained_var` per trainable module with a CI assertion
+behind it (§2.1).
 
 ```python
 # in on_train_result / on_episode_end
@@ -234,17 +285,13 @@ metrics_logger.log_value("vf_explained_var", ...,  window=1)
 
 Highest-value additions, in order:
 
-1. **Write each iteration's result dict to `results/progress.jsonl`**, so a run leaves a queryable
-   history behind without adopting `tune.Tuner`.
-2. **Log `vf_explained_var`** and assert on it in CI — it is the one metric that would have
-   caught S1-1.
-3. **Log reward sub-components** into `metrics_logger` from `on_episode_step` / `on_episode_end`.
-4. **Log per-agent final account state** — NAV, position, drawdown, VWAP — at episode end.
-5. **Log the do-nothing action fraction and the order rejection rate**, so passivity collapse and
+1. **Log reward sub-components** into `metrics_logger` from `on_episode_step` / `on_episode_end`.
+2. **Log per-agent final account state** — NAV, position, drawdown, VWAP — at episode end.
+3. **Log the do-nothing action fraction and the order rejection rate**, so passivity collapse and
    blind modify/cancel actions become measurable.
-6. **Export market price and spread** into the info dict — already in env state, just not
+4. **Export market price and spread** into the info dict — already in env state, just not
    surfaced.
-7. **Per-episode desk metrics** (Sharpe, max drawdown, turnover, maker ratio, inventory) through
+5. **Per-episode desk metrics** (Sharpe, max drawdown, turnover, maker ratio, inventory) through
    `metrics_logger`, so they land in TensorBoard alongside returns. The `on_episode_end` hook
    already has everything it needs. See
    [13_perspective_financial_trader.md](13_perspective_financial_trader.md) §7.

--- a/doc/11_logging_and_observability.md
+++ b/doc/11_logging_and_observability.md
@@ -114,12 +114,17 @@ end to end, so trading moves cash and never creates it. This was a good idea imp
 
 ```python
 if metrics_logger:
-    metrics_logger.log_value("nav_conservation_error", abs(error), window=1)
+    metrics_logger.log_value("nav_conservation_error", float(abs(error)), window=1)
 if not conserved:
     logger.error(message)
     if self.strict_nav_check:
         raise AssertionError(message)
 ```
+
+The check is **`Decimal` end to end**. `info["NAV"]` is the exact `str()` of a `Decimal`
+(§2.6), so it is parsed back with `Decimal`, and `total_initial_cash` is built as a `Decimal`
+too; `float()` is applied only where the value leaves for the metrics stack, which reduces with
+NumPy and will not take a `Decimal`. The comparison that decides the raise is therefore exact.
 
 * The **metric goes out either way**, so a run has a series to inspect rather than only the moment
   it broke. `window=1` keeps it per-iteration: an error in one episode out of many must not be
@@ -128,10 +133,17 @@ if not conserved:
   every reward computed from NAV afterwards is meaningless, so the run stops. Set it false in
   `train_config.json`, or pass `--no-strict-nav-check`, for a run that would rather finish and be
   inspected afterwards; the ERROR log and the metric still happen.
-* **`nav_tolerance`** (default `1e-6`) absorbs the `float()` round trip through the info dict
-  (§2.6), nothing larger. Widen it only for a change that legitimately removes cash from the
-  system, such as fees - see [13_perspective_financial_trader.md](13_perspective_financial_trader.md)
-  §4.
+* **`nav_tolerance`** (default `1e-6`) is headroom for a change that legitimately removes cash
+  from the system, such as fees - see
+  [13_perspective_financial_trader.md](13_perspective_financial_trader.md) §4. It is **not**
+  absorbing arithmetic noise: with the check exact, the expected error is `0`, and the tolerance
+  can be set to `0` to enforce that — the comparison is `abs(error) <= nav_tolerance`, inclusive,
+  so `0` means "conservation must be exact" rather than "every episode is a violation". At the
+  default the inclusive and exclusive forms differ only on an error of exactly `1e-6`.
+  The `float()` round trip it was previously credited with
+  absorbing was harmless at the default `init_cash` — but above `init_cash ≈ 1e10` it made the
+  check unable to resolve this very tolerance, passing corrupt ledgers silently. See
+  [16 §16.10](16_verification_log.md).
 
 Covered by `test_nav_callback.py` (6 tests): conservation passes and logs a zero error, a
 violation raises under the default, the metric is emitted before the raise, non-strict logs ERROR

--- a/doc/11_logging_and_observability.md
+++ b/doc/11_logging_and_observability.md
@@ -227,6 +227,59 @@ exactly, penalties matching coefficient × counter, the counters being read *bef
 `set_step_outputs` zeroes them, `spread` on a one-sided book, and the whole dict surviving
 `json.dumps`.
 
+### 1.8 The type policy
+
+Everything above assumes a field means one thing and holds one type. Before this, four did not.
+
+| Kind | Type | Fields |
+|---|---|---|
+| Money | `Decimal` | `cash`, `cash_on_hold`, `position_val`, `init_nav`, `nav`, `prev_nav`, `max_nav`, `profit`, `total_profit` |
+| Price | `Decimal` | order and trade `price`, `VWAP`, `best_bid`, `best_ask`, `spread` |
+| Size | `int` | order and trade `quantity`, `net_position`, `num_trades`, the per-step counters |
+| Signal | `float` | `reward`, `drawdown` |
+
+**Why it is not cosmetic.** `Decimal * float` raises `TypeError`; `Decimal * int` does not. The
+orderbook carries two local workarounds for exactly that error, both commented with the traceback
+they came from (`orderbook.py:76-79`, `:99-100`), and `cash_processor.py:78` computes
+`Decimal(str(price)) * qoute['quantity']`, which would raise on the modify path with a float size.
+Sizes being `int` makes that class of failure unreachable rather than worked around.
+
+The second failure is a field that changes type partway through an episode, which breaks any
+consumer that checks it. Measured over a real run, before the fix: `net_position` was `int` until
+the first fill and `Decimal` after; `VWAP` was `Decimal` until a position went flat, then `int`
+(a bare `0` at `account.py:136`); `reward` was `int` until the first `set_reward`; `drawdown` was
+`Decimal` until the first step.
+
+**Signals are the deliberate exception.** `reward` must be a `float` — RLlib requires it — and
+`drawdown` feeds the reward. They are learning signals, not money. The observation is `float32`
+by construction, so prices and sizes are converted at that boundary too.
+
+**`last_price` is the other exception**, and it stays a `float`. It never reaches the ledger:
+`mark_to_mkt` passes the tape's `Decimal` to the account, while `last_price` is a separate anchor
+consumed only by `_set_price`'s NumPy arithmetic and by `state_helper`, which already wraps it in
+`float()`. Making it a `Decimal` would mean converting back at both consumers and buys no
+exactness.
+
+**`envs/orderbook/` is deliberately not changed** — see `ec1f5ea`, "Intentional revert because I
+don't want code in orderbook folder to change." The book stores sizes as `Decimal` (`order.py:12`
+coerces on the way in), and a fill reports whichever type its branch happened to hold:
+`quantity_to_trade` (int) on a partial or exact fill, `head_order.quantity` (Decimal) when the
+incoming order is larger — 84 against 10 on one tape. That mixing is absorbed at the single point
+every trade passes through, `trader._normalise_trade_sizes`, before any account arithmetic sees
+it. The coercion is lossless by construction rather than by luck: ints go in, the book only
+subtracts whole sizes from whole sizes, and a fractional size raises instead of truncating
+silently.
+
+Sizes are `int` at ingress too (`action_helper.py:250`), which is a separate guarantee: the old
+`(size + min_size) * 1.0` — commented *"\*1 for float"* — was the single character that made every
+downstream size a float. Egress normalisation hides an ingress regression completely, so both ends
+are pinned by `test_type_policy.py` (15 tests); the ingress tests exist precisely because a
+mutation restoring that `* 1.0` left every other test in the file green.
+
+**`info` is a serialisation boundary, not part of the policy.** JSON has no `Decimal`, so money
+and prices are emitted as `float` there, except `NAV`, which pays the string cost because the
+conservation check (§1.5) depends on its exactness. Sizes need no conversion — `int` is JSON-native.
+
 ---
 
 ## 2. What is not logged but should be

--- a/doc/15_findings_and_recommendations.md
+++ b/doc/15_findings_and_recommendations.md
@@ -312,6 +312,15 @@ split, adverse-selection mark-outs. The counters for several of these already ex
 discarded after the reward consumes them. `info["NAV"]` is a **string**, round-tripped through
 `float()` by every consumer, discarding the exactness `Decimal` was chosen for.
 
+**Partly addressed:** the episode-end NAV conservation check now parses `info["NAV"]` back with
+`Decimal` and compares against a `Decimal` total, so that one consumer is exact by construction;
+`float()` remains only at the metrics boundary. [16 §16.10](16_verification_log.md) shows the
+round trip was harmless at the default `init_cash = 1e6`, but that **above `init_cash ≈ 1e10` the
+float check could not resolve its own `1e-6` tolerance** — a genuine breach read as exactly `0.0`
+and would have passed a corrupt ledger silently. It also corrects the claim that `nav_tolerance`
+was absorbing float noise. The missing risk-adjusted metrics above, and the remaining `float()`
+consumers of `info["NAV"]`, are untouched.
+
 ### S3-10 · A trader can hold only one resting order per price level **[verified]**
 
 A second limit at the same price *replaces* the first (level volume 7, not 12) —

--- a/doc/16_verification_log.md
+++ b/doc/16_verification_log.md
@@ -412,7 +412,76 @@ corrections in [README.md](../README.md).
 
 ---
 
-## 16.10 Reproducing these probes
+## 16.10 NAV conservation is exact; the `float()` round trip went blind above `init_cash` 1e10
+
+The episode-end check used to parse `info["NAV"]` — the exact `str()` of a `Decimal` — back with
+`float()`. Three probes, run to decide whether that round trip was doing any harm and whether
+`nav_tolerance` was absorbing it as the config note claimed.
+
+**Probe A — 300-step rollout, 4 agents, `init_cash = 1,000,000`, uniformly random actions.**
+Comparing, at every step, the sum of agent NAVs against `init_cash × 4`:
+
+```
+steps compared: 300
+  exactly conserved under Decimal: 300/300
+  exactly conserved under float  : 300/300
+```
+
+Conservation is exact under *both* readings. Individual NAVs do carry long fractional tails —
+the Decimal residual prints as `0E-21`, i.e. an exact zero at 21 decimal places of scale — but
+they cancel.
+
+**Probe B — scale sweep, `init_cash` from `1e6` to `1e15`,** measuring how far the float reading
+of the NAV sum falls from the Decimal one:
+
+```
+init_cash=1e6   reading differs by 2.8e-20    breaches 1e-6 = False
+init_cash=1e7   reading differs by 4.0e-20    breaches 1e-6 = False
+init_cash=1e8 … 1e15  reading differs by 0    breaches 1e-6 = False
+```
+
+The float error cancels because `total_nav` and `total_initial_cash` were computed at the same
+magnitude, so the subtraction removes the common rounding. On these two probes alone the round
+trip looks harmless — which is why the third probe matters.
+
+**Probe C — detection, not representation.** Inject a *genuine* breach of `2e-6` (just over
+`nav_tolerance`) and ask which reading still sees it:
+
+```
+init_cash=1e6   decimal_detects=True   float_detects=True   (float read 2.00002e-06)
+init_cash=1e7   decimal_detects=True   float_detects=True   (float read 1.99676e-06)
+init_cash=1e8   decimal_detects=True   float_detects=True   (float read 2.02656e-06)
+init_cash=1e9   decimal_detects=True   float_detects=True   (float read 1.90735e-06)
+init_cash=1e10  decimal_detects=True   float_detects=False  (float read 0)
+init_cash=1e11  decimal_detects=True   float_detects=False  (float read 0)
+init_cash=1e12  decimal_detects=True   float_detects=False  (float read 0)
+```
+
+**Conclusion.** Two things, and the second is the one that justifies the change.
+
+1. At the default `init_cash = 1e6` the round trip was harmless, and `nav_tolerance` was **not**
+   absorbing arithmetic noise — the justification given in `train_config.json` and
+   [11 §1.5](11_logging_and_observability.md) was wrong on that point, and both are corrected.
+2. **Above `init_cash ≈ 1e10` the float check could not resolve its own tolerance.** A real
+   quarter-dollar of destroyed cash at `init_cash = 1e15` reads as exactly `0.0`; float's spacing
+   there is `0.5`. The check would pass a corrupt ledger silently — the precise failure
+   `strict_nav_check` exists to prevent. Note also that even where detection succeeds, the float
+   *reading* is off (`1.90735e-06` for a true `2e-06`), so the `nav_conservation_error` metric was
+   already imprecise at `1e9`.
+
+The check is now `Decimal` end to end: exact by construction rather than by a cancellation that
+happens to hold at one account size, with an expected error of `0` that `nav_tolerance` may be set
+to `0` to enforce. `float()` survives only at the metrics boundary, which reduces with NumPy.
+The default configuration was ~4 orders of magnitude from the cliff, so no existing run was
+affected.
+
+**Supports:** the correction to S3-9 in
+[15_findings_and_recommendations.md](15_findings_and_recommendations.md), and
+[11 §1.5](11_logging_and_observability.md).
+
+---
+
+## 16.11 Reproducing these probes
 
 The rollout probes (16.3–16.6) are a single self-contained script that imports
 `continuousDoubleAuctionEnv` directly. The training probe (16.7) builds a real `Algorithm`

--- a/doc/17_changelog.md
+++ b/doc/17_changelog.md
@@ -648,3 +648,55 @@ append-across-a-restart case, numpy and NaN handling, and a write failure that m
 loop.
 
 See [11_logging_and_observability.md](11_logging_and_observability.md) §1.6.
+
+---
+
+## 19. A step leaves a record behind
+
+§18 gave the *run* a history. The *step* still had almost none: `Info_Helper.set_info` reported
+`reward`, `NAV` and `num_trades`, and everything else a step knew about itself was computed,
+consumed and dropped inside the same function call. The position was in the account, the drawdown
+was calculated in `set_reward` and thrown away the moment the penalty was charged, the spread was
+derived in `state_helper` as `log1p(spread_ticks)` for the observation and the raw number
+discarded, and the five reward components existed only as terms in one expression. Every question
+in [11](11_logging_and_observability.md) §2.2–2.4 was unanswerable not because the data was hard
+to get, but because nothing kept it.
+
+**The per-step `info` dict now carries account state, market state, the reward decomposition and
+the submitted action** — see [11 §1.7](11_logging_and_observability.md) for the field list. The
+original three fields are untouched in name, type and order, and `NAV` remains the exact `str()`
+of a `Decimal` so the conservation check (§1.5) and `visualize_nav.py` both keep working.
+
+Four decisions in that change were not obvious, and one of them was a trap.
+
+**The reward terms sum to the reward, and the sum is the reward.** `set_reward` builds a dict of
+signed contributions and accumulates it, rather than keeping the old expression and computing a
+parallel breakdown beside it. A decomposition that can drift from the number the agent was trained
+on is worse than no decomposition, because it looks authoritative.
+
+**The trap: `sum()` would have changed the reward.** The obvious way to write that accumulation is
+`sum(terms.values())`. On Python 3.12+ the builtin applies Neumaier compensated summation to
+floats — it is *more* accurate than the original left-to-right expression, and it disagrees with
+it on ~44% of random inputs, by ~1e-13 relative. `math.fsum` likewise. Adding instrumentation must
+not perturb what is being instrumented, so the reward is accumulated with an explicit loop, which
+reproduces the previous arithmetic bit for bit — verified over 200,000 random inputs. Iterating
+the dict rather than naming the five keys also means a sixth term added later cannot be logged but
+left out of the reward.
+
+**`net_position` is reported as a float.** `account.py` initialises it to `int` 0 and then
+rebuilds it as a `Decimal` on the first fill, so its type changes partway through every episode.
+That is a latent inconsistency in the account, not something this change fixes; reporting one type
+throughout at least keeps it from reaching consumers.
+
+**`spread` is `None`, not `0.0`, when the book is one-sided.** The observation needs a finite
+sentinel and uses `0.0`. A log does not, and `0.0` there could not be told apart from a book whose
+touch is one tick wide — the collision [15](15_findings_and_recommendations.md) S3-14 describes.
+
+`test_info_dict.py` (18 tests) covers the back-compat of the original three fields, the terms
+summing exactly, penalties equalling coefficient × counter, `spread` on a one-sided book, and the
+whole dict surviving `json.dumps` — a numpy `int64` in `info` would break the progress log, and
+unlike `np.float64` it does not subclass its Python counterpart. One of those tests was checked by
+mutation: moving the per-step counter reset to before `set_info` makes it fail, which is the point
+— the counters would otherwise log a valid, healthy-looking, permanent 0.
+
+See [11 §1.7](11_logging_and_observability.md) and [07 §6.4](07_reward_function.md).

--- a/doc/17_changelog.md
+++ b/doc/17_changelog.md
@@ -700,3 +700,51 @@ mutation: moving the per-step counter reset to before `set_info` makes it fail, 
 — the counters would otherwise log a valid, healthy-looking, permanent 0.
 
 See [11 §1.7](11_logging_and_observability.md) and [07 §6.4](07_reward_function.md).
+
+---
+
+## 20. Money in Decimal, sizes in int
+
+The account was `Decimal` where it mattered, but four of its fields did not hold one type for a
+whole episode. Measured over a real run: `net_position` was `int` until the first fill and
+`Decimal` after; `VWAP` was `Decimal` until a position went flat and `int` after, from a bare `0`
+at `account.py:136`; `reward` was `int` until the first `set_reward`; `drawdown` was `Decimal`
+until the first step, introduced by §19, the change that documented the pattern.
+
+The policy is now explicit — money and prices `Decimal`, sizes `int`, `reward` and `drawdown`
+`float` — and enforced by `test_type_policy.py` (15 tests) rather than left to convention. See
+[11 §1.8](11_logging_and_observability.md).
+
+**This is not tidiness.** `Decimal * float` raises `TypeError`; `Decimal * int` does not. The
+orderbook already carries two workarounds for that exact error, each commented with the traceback
+it came from, and `cash_processor.py:78` computes `Decimal(str(price)) * qoute['quantity']`, which
+would raise on the modify path with a float size. Making sizes `int` removes the failure mode
+instead of adding a third workaround.
+
+**The orderbook is untouched**, per `ec1f5ea`. It stores sizes as `Decimal` — `order.py:12`
+coerces on the way in — so a fill reports whichever type its branch held: `quantity_to_trade`
+(int) on a partial or exact fill, `head_order.quantity` (Decimal) when the incoming order is the
+larger one, 84 against 10 on one tape. Rather than change the book, the mixing is absorbed at the
+one point every trade passes through on its way into env code, `trader._normalise_trade_sizes`.
+That coercion is lossless by construction and not by luck: ints go in, the book only subtracts
+whole sizes from whole sizes, and a fractional size raises rather than truncating silently.
+
+Sizes are also `int` at ingress. The old `act["size"] = (size + self.min_size) * 1.0`, commented
+*"\*1 for float"*, was the single character that made every downstream size a float.
+
+**A mutation test earned its keep here.** Restoring that `* 1.0` left all thirteen type tests
+green, because the egress normalisation absorbs float sizes so completely that the account never
+sees the difference. The tests could not distinguish a working ingress from a broken one. Two
+ingress tests were added for that reason, and the same mutation now fails both — which matters
+because `cash_processor`'s modify path is reached by orders, not by the trades the egress tests
+inspect.
+
+Two deliberate exceptions. `reward` and `drawdown` stay `float`: RLlib requires float rewards and
+the drawdown feeds the reward, so they are learning signals rather than money. `last_price` stays
+`float` because it never reaches the ledger — `mark_to_mkt` hands the account the tape's `Decimal`,
+while `last_price` is a separate anchor consumed only by `_set_price`'s NumPy arithmetic and by
+`state_helper`, which already wraps it in `float()`.
+
+`info` is unaffected as a format, being a serialisation boundary where JSON has no `Decimal` —
+except that `net_position` is now a plain `int` rather than a `float()` cast that existed only to
+hide the account changing type underneath it.

--- a/doc/17_changelog.md
+++ b/doc/17_changelog.md
@@ -598,3 +598,53 @@ Unchanged and already documented as S1-1: `vf_loss` pinned at the `vf_clip_param
 receives no gradient, PPO degenerates to REINFORCE, and `best_trainable` across the 16 iterations
 of either run is noise with no trend. The infrastructure now works end to end; the learning
 problem is untouched.
+
+---
+
+## 18. A run leaves a record behind
+
+The two GPU runs in §17 could only be diagnosed after the fact, from scrollback, because
+`algo.train()` returns a full metrics dict every iteration and the driver loop read two keys out
+of it — `num_env_steps_sampled` and `module_episode_returns_mean` — for a log line and dropped the
+rest. The loop calls `algo.train()` directly rather than through `tune.Tuner`, so nothing wrote
+`progress.csv` or TensorBoard events either. A finished run left checkpoints and no history.
+
+**Every iteration now appends its whole result dict to `<log_base_dir>/progress.jsonl`.** Not a
+chosen subset: the loss terms, KL, entropy, timers and learner stats are all in there, because
+deciding in advance which of them a future question needs is what produced this gap. A
+`_json_safe` pass runs first, since RLlib results carry numpy scalars and arrays, the occasional
+object with no JSON form, and NaNs — numbers stay numbers rather than being stringified by a bare
+`default=str`, non-finite floats become `null` because `NaN` is not valid JSON, and anything left
+over is stringified. The file is opened and closed per iteration so a killed run keeps the
+iterations it finished, and every failure inside the writer is swallowed with a warning:
+instrumentation must not be what takes down a run that is otherwise training fine.
+
+**`vf_explained_var` is now in the per-iteration log line**, per trainable module, beside the
+returns. This is the metric §17.3 identifies as the one that exposes S1-1, and nothing surfaced
+it — which is why a critic pinned at 0.0 survived two full runs. It is read from
+`result["learners"][<module_id>]`, keyed on `trainable_policy_ids`: only the modules in
+`policies_to_train` appear there, so the frozen champions and the random baselines are absent by
+construction. A module missing from the result is omitted rather than reported as 0.0, since
+"absent" and "the critic explains nothing" are different states and telling them apart is the
+whole point.
+
+**CI asserts on it.** `test/integration/test_progress_and_vf.py` trains a real PPO for three
+iterations at the existing tiny test size and checks that the file has one line per iteration,
+that a real result survives the JSON round trip, and that every trainable module reports a finite
+`vf_explained_var`.
+
+The obvious next assertion — `!= 0.0`, the value a critic that never received a gradient reports —
+was written, run, and thrown away, because it **passes on this repository today**. A run of the
+suite reports values around 1e-5, matching the "0.0 to 1.8e-07" that §17.3 records from the two
+GPU runs, and all of it is nonzero: floating-point noise is not evidence of learning, so the
+assertion would have guarded nothing while looking like it guarded the defect. What is there
+instead is `test_the_critic_actually_explains_something`, asserting `|vf_explained_var| >= 1e-3`
+under a **strict xfail**. It fails today because S1-1 is open. When S1-1 is fixed it XPASSes and
+fails the build, at which point the marker comes off and it becomes the live regression guard it
+cannot be while the defect is still there.
+
+`test_progress_log.py` (19 tests) covers the writer itself against hand-built results — the
+append-across-a-restart case, numpy and NaN handling, and a write failure that must not stop the
+loop.
+
+See [11_logging_and_observability.md](11_logging_and_observability.md) §1.6.

--- a/gym_continuousDoubleAuction/envs/account/account.py
+++ b/gym_continuousDoubleAuction/envs/account/account.py
@@ -34,6 +34,13 @@ class Account(Calculate, Cash_Processor):
         self.num_passive_fills_step = 0 # passive executions in current step
         self.order_step_placed = 0 # 1 if a Market/Limit order was placed this step
 
+        # Written by Reward_Helper.set_reward each step, read by Info_Helper.
+        # The reward used to be a single number with its five components
+        # discarded the moment it was summed, which is what made the variance
+        # split in doc/07 6.4 unmeasurable. See doc/11 2.4.
+        self.drawdown = Decimal(0) # max_nav - nav, the level the penalty uses
+        self.reward_terms = {} # signed contributions, summing to self.reward
+
     def reset_acc(self, ID, cash=env_default("init_cash")):
         self.ID = ID
         self.cash = Decimal(cash)
@@ -57,6 +64,10 @@ class Account(Calculate, Cash_Processor):
         self.num_trades_step = 0
         self.num_passive_fills_step = 0
         self.order_step_placed = 0
+
+        # See __init__ for what these are and why they exist.
+        self.drawdown = Decimal(0)
+        self.reward_terms = {}
 
     def print_acc(self, msg):
         acc = {}

--- a/gym_continuousDoubleAuction/envs/account/account.py
+++ b/gym_continuousDoubleAuction/envs/account/account.py
@@ -38,7 +38,10 @@ class Account(Calculate, Cash_Processor):
         # The reward used to be a single number with its five components
         # discarded the moment it was summed, which is what made the variance
         # split in doc/07 6.4 unmeasurable. See doc/11 2.4.
-        self.drawdown = Decimal(0) # max_nav - nav, the level the penalty uses
+        # float, not Decimal(0): set_reward stores float(max(0, max_nav - nav)),
+        # so initialising this as a Decimal would make the field change type on
+        # the first step - the same defect net_position and VWAP already have.
+        self.drawdown = 0.0 # max_nav - nav, the level the penalty uses
         self.reward_terms = {} # signed contributions, summing to self.reward
 
     def reset_acc(self, ID, cash=env_default("init_cash")):
@@ -66,7 +69,7 @@ class Account(Calculate, Cash_Processor):
         self.order_step_placed = 0
 
         # See __init__ for what these are and why they exist.
-        self.drawdown = Decimal(0)
+        self.drawdown = 0.0
         self.reward_terms = {}
 
     def print_acc(self, msg):

--- a/gym_continuousDoubleAuction/envs/account/account.py
+++ b/gym_continuousDoubleAuction/envs/account/account.py
@@ -26,7 +26,10 @@ class Account(Calculate, Cash_Processor):
         self.profit = Decimal(0) # profit @ each trade(tick) within a single t step
         self.total_profit = Decimal(0) # profit at the end of a single t-step
         self.num_trades = 0
-        self.reward = 0
+        # float, not int: set_reward assigns a float, and RLlib requires float
+        # rewards. Reward is a learning signal, not money - it is the one thing
+        # in this account that is deliberately neither Decimal nor int.
+        self.reward = 0.0
 
         # New metrics for improved reward function
         self.max_nav = Decimal(cash) # peak nav seen so far
@@ -60,7 +63,7 @@ class Account(Calculate, Cash_Processor):
         self.profit = Decimal(0) # profit @ each trade(tick) within a single t step
         self.total_profit = Decimal(0) # profit at the end of a single t-step
         self.num_trades = 0
-        self.reward = 0
+        self.reward = 0.0
 
         # New metrics for improved reward function
         self.max_nav = Decimal(cash)
@@ -113,7 +116,8 @@ class Account(Calculate, Cash_Processor):
         return 0
 
     def _size_increase(self, trade, position, party, trade_val):
-        total_size = abs(self.net_position) + Decimal(trade.get('quantity'))
+        # Sizes add in int; only the value terms below are Decimal.
+        total_size = abs(self.net_position) + int(trade.get('quantity'))
         # VWAP
         self.VWAP = (abs(self.net_position) * self.VWAP + trade_val) / total_size
         raw_val = total_size * self.VWAP # value acquired with VWAP
@@ -131,13 +135,15 @@ class Account(Calculate, Cash_Processor):
         mkt_val = abs(self.net_position) * trade.get('price')
         self.position_val = raw_val + self.cal_profit(position, mkt_val, raw_val)
         self.size_zero_cash_transfer(mkt_val)
-        # reset to 0
-        self.position_val = 0
-        self.VWAP = 0
+        # reset to 0 - as Decimal, not int. position_val is money and VWAP is a
+        # price, so both are Decimal everywhere else; assigning a bare 0 here
+        # was what made VWAP read back as an int once a position went flat.
+        self.position_val = Decimal(0)
+        self.VWAP = Decimal(0)
         return mkt_val
 
     def _size_decrease(self, trade, position, party, trade_val):
-        size_left = abs(self.net_position) - Decimal(trade.get('quantity'))
+        size_left = abs(self.net_position) - int(trade.get('quantity'))
         if size_left > 0:
             self.VWAP = (abs(self.net_position) * self.VWAP - trade_val) / size_left
             raw_val = size_left * self.VWAP # value acquired with VWAP
@@ -152,7 +158,7 @@ class Account(Calculate, Cash_Processor):
         mkt_val = self._covered(trade, position)
         self.size_decrease_cash_transfer(party, mkt_val)
         # deal with remaining size that cause position change
-        new_size = Decimal(trade.get('quantity')) - abs(self.net_position)
+        new_size = int(trade.get('quantity')) - abs(self.net_position)
         self.position_val = new_size * trade.get('price') # traded value
         self.VWAP = trade.get('price')
         self.size_increase_cash_transfer(party, self.position_val)
@@ -182,20 +188,22 @@ class Account(Calculate, Cash_Processor):
                 self._covered_side_chg(trade, 'short', party)
 
     def _update_net_position(self, side, trade_quantity):
+        # int throughout: a net position is a count of contracts. The Decimal()
+        # wrapping this used to carry was working around float sizes coming out
+        # of the book - with sizes normalised to int at that boundary
+        # (trader._normalise_trade_sizes) the arithmetic is exact in int, and
+        # the field no longer changes type on the first fill.
+        trade_quantity = int(trade_quantity)
         if self.net_position >= 0: # long or neutral
             if side == 'bid':
-                #self.net_position += trade_quantity
-                self.net_position = Decimal(self.net_position) + Decimal(trade_quantity)
+                self.net_position += trade_quantity
             else:
-                #self.net_position += -trade_quantity
-                self.net_position = Decimal(self.net_position) - Decimal(trade_quantity)
+                self.net_position -= trade_quantity
         else: # short
             if side == 'ask':
-                #self.net_position += -trade_quantity
-                self.net_position = Decimal(self.net_position) - Decimal(trade_quantity)
+                self.net_position -= trade_quantity
             else:
-                #self.net_position += trade_quantity
-                self.net_position = Decimal(self.net_position) + Decimal(trade_quantity)
+                self.net_position += trade_quantity
         return 0
 
     def process_acc(self, trade, party):

--- a/gym_continuousDoubleAuction/envs/agent/trader.py
+++ b/gym_continuousDoubleAuction/envs/agent/trader.py
@@ -8,6 +8,39 @@ from ..account.account import Account
 from .random_agent import Random_agent
 from ...config_loader import env_default
 
+
+def _normalise_trade_sizes(trades):
+    """Coerce the sizes in the book's trade records back to int, in place.
+
+    Sizes enter the book as int, but `Order.__init__` stores them as `Decimal`,
+    so a fill reports whichever the branch that produced it happened to hold:
+    `quantity_to_trade` (int) on a partial or exact fill, `head_order.quantity`
+    (Decimal) when the incoming order is the larger one. Measured over a 120
+    step run that is 84 int against 10 Decimal on the same tape.
+
+    The orderbook is deliberately left untouched (see doc/11 1.8), so the mixing
+    is absorbed here instead - at the one point every trade passes through,
+    before any account arithmetic sees it. This is the *only* place env code
+    should have to think about it.
+
+    Lossless by construction, not by luck: ints go in, and the book only ever
+    subtracts one whole size from another, so every quantity out is integral.
+    The assertion says so out loud rather than letting a fractional size become
+    a silent truncation.
+    """
+    for trade in trades:
+        quantity = trade.get('quantity')
+        if quantity is None:
+            continue
+        as_int = int(quantity)
+        if as_int != quantity:
+            raise ValueError(
+                f"non-integral trade size {quantity!r} out of the order book: "
+                f"sizes are counts of contracts and must stay whole"
+            )
+        trade['quantity'] = as_int
+
+
 class Trader(Random_agent):
     def __init__(self, ID, cash=env_default("init_cash")):
         self.ID = ID # trader unique ID
@@ -54,6 +87,7 @@ class Trader(Random_agent):
                 return trades, order_in_book
 
             if trades != []: # if trades took placed in this order
+                _normalise_trade_sizes(trades)
                 self._process_trades(trades, agents)
 
             self.acc.order_in_book_passive_party(order_in_book) # if there's any unfilled

--- a/gym_continuousDoubleAuction/envs/exchg/action_helper.py
+++ b/gym_continuousDoubleAuction/envs/exchg/action_helper.py
@@ -240,7 +240,14 @@ class Action_Helper():
         act["side"], act["type"] = _CATEGORY_MAP[int(category)]
 
         size = self._set_size(act["type"], self.mkt_size_mean_mul, self.limit_size_mean_mul, size_mean, size_sigma)
-        act["size"] = (size + self.min_size) * 1.0 # +self.min_size as size can't be 0, *1 for float
+        # int, not float. A size is a count of contracts, so int is the type
+        # that can represent it exactly; the previous `* 1.0` coerced to float
+        # deliberately ("*1 for float") and that single character is why sizes
+        # were floats everywhere downstream. Decimal * int is defined, whereas
+        # Decimal * float raises TypeError - which is the error the orderbook
+        # already carries two local workarounds for, and the one
+        # cash_processor's modify path would hit. See doc/11 1.8.
+        act["size"] = int(size + self.min_size) # +self.min_size as size can't be 0
 
         if act["type"] == 'market':
             act["price"] = -1.0 # -1.0 to indicate market price
@@ -295,7 +302,10 @@ class Action_Helper():
             sample = np.random.normal(limit_size_mean_mul * mean, sigma, 1)
 
         # return np.asscalar(np.rint(np.abs(sample)))
-        return np.rint(np.abs(sample)).item()
+        # int(): np.rint already rounds to a whole number, but .item() hands
+        # back a Python float (40.0), and np.int64 is not an int subclass, so
+        # neither is usable as a size without a further conversion.
+        return int(np.rint(np.abs(sample)).item())
 
     def _set_price(self, min_tick, side, price_code, price_offset=None):
         """

--- a/gym_continuousDoubleAuction/envs/exchg/exchg_helper.py
+++ b/gym_continuousDoubleAuction/envs/exchg/exchg_helper.py
@@ -65,6 +65,32 @@ class Exchg_Helper(State_Helper, Action_Helper, Reward_Helper, Done_Helper, Info
                 trader.acc.mark_to_mkt(trader.ID, mkt_price)
         return 0
 
+    def set_market_snapshot(self):
+        """Record top of book and the spread for this step.
+
+        The spread was previously computed nowhere durable: `state_helper`
+        derives `log1p(spread_ticks)` for the observation and discards the raw
+        number, so the single most-used market-quality metric never reached a
+        log (doc/11 2.2).
+
+        `None` rather than 0.0 when a side is empty. The observation needs a
+        finite sentinel and uses 0.0 for "no two-sided market"; a log does not,
+        and 0.0 there would be indistinguishable from a genuinely crossed-to-
+        touching book - the ambiguity doc/15 S3-14 is about. `None` encodes as
+        JSON null.
+        """
+        best_bid = self.LOB.get_best_bid()
+        best_ask = self.LOB.get_best_ask()
+
+        self.best_bid = float(best_bid) if best_bid is not None else None
+        self.best_ask = float(best_ask) if best_ask is not None else None
+        if self.best_bid is not None and self.best_ask is not None:
+            self.spread = self.best_ask - self.best_bid
+        else:
+            self.spread = None
+
+        return 0
+
     def set_step_outputs(self, state_input):
         """
         Set outputs for each step.
@@ -75,6 +101,11 @@ class Exchg_Helper(State_Helper, Action_Helper, Reward_Helper, Done_Helper, Info
         Return:
             next_states, rewards, dones, infos
         """
+
+        # Once per step, not once per trader: the book is the same for all of
+        # them, and set_info reads it off self the way it already reads
+        # last_price.
+        self.set_market_snapshot()
 
         next_states, rewards, dones, infos = {},{},{},{}
         for trader in self.traders:

--- a/gym_continuousDoubleAuction/envs/exchg/exchg_helper.py
+++ b/gym_continuousDoubleAuction/envs/exchg/exchg_helper.py
@@ -79,11 +79,10 @@ class Exchg_Helper(State_Helper, Action_Helper, Reward_Helper, Done_Helper, Info
         touching book - the ambiguity doc/15 S3-14 is about. `None` encodes as
         JSON null.
         """
-        best_bid = self.LOB.get_best_bid()
-        best_ask = self.LOB.get_best_ask()
-
-        self.best_bid = float(best_bid) if best_bid is not None else None
-        self.best_ask = float(best_ask) if best_ask is not None else None
+        # Decimal, as the book already reports them: these are prices, and
+        # prices stay Decimal until something serialises them (doc/11 1.8).
+        self.best_bid = self.LOB.get_best_bid()
+        self.best_ask = self.LOB.get_best_ask()
         if self.best_bid is not None and self.best_ask is not None:
             self.spread = self.best_ask - self.best_bid
         else:

--- a/gym_continuousDoubleAuction/envs/exchg/info_helper.py
+++ b/gym_continuousDoubleAuction/envs/exchg/info_helper.py
@@ -1,3 +1,25 @@
+import numpy as np
+
+
+def _plain(value):
+    """Convert a numpy scalar or array into something JSON can hold.
+
+    Actions arrive from the model as a tuple mixing `np.int32` with
+    single-element `float32` arrays. `json.dumps` handles none of that, and the
+    per-iteration progress log (doc/11 1.6) is only useful if what goes into
+    `info` can actually be written out.
+    """
+    if isinstance(value, np.ndarray):
+        return [_plain(v) for v in value.tolist()]
+    if isinstance(value, np.generic):
+        return value.item()
+    if isinstance(value, dict):
+        return {k: _plain(v) for k, v in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_plain(v) for v in value]
+    return value
+
+
 class Info_Helper(object):
 
     def set_info(self, infos, trader):
@@ -12,11 +34,68 @@ class Info_Helper(object):
             dict: Updated infos dictionary.
         """
         agent_key = f'agent_{trader.ID}'
-        
-        infos[agent_key] = {
-            "reward": trader.acc.reward,
-            "NAV": str(trader.acc.nav),
-            "num_trades": trader.acc.num_trades
+        acc = trader.acc
+
+        # `reward`, `NAV` and `num_trades` keep their names, types and order.
+        # NAV stays a string: it is the exact str() of a Decimal, which is what
+        # lets the conservation check parse it back without loss, and both
+        # consumers already handle it (doc/11 2.6 tracks the round trip itself).
+        #
+        # The fields below are diagnostics rather than invariants, so they go
+        # out as plain numbers - float is what the metrics stack and json
+        # consume, and nothing reconstructs the ledger from them.
+        info = {
+            "reward": acc.reward,
+            "NAV": str(acc.nav),
+            "num_trades": acc.num_trades,
         }
+
+        # Account state (doc/11 2.3). Read before set_step_outputs zeroes the
+        # per-step counters, which happens after this call.
+        info.update({
+            # float(), despite account.py initialising this to int 0: the
+            # position becomes a Decimal the moment a trade lands (account.py
+            # rebuilds it as Decimal +/- Decimal), so the type is int before the
+            # first fill and Decimal after. Contract counts are integral, so
+            # float loses nothing and the key holds one type all episode.
+            "net_position": float(acc.net_position),
+            "VWAP": float(acc.VWAP),
+            "cash": float(acc.cash),
+            "cash_on_hold": float(acc.cash_on_hold),
+            "position_val": float(acc.position_val),
+            "drawdown": float(acc.drawdown),
+            "max_nav": float(acc.max_nav),
+            "num_trades_step": acc.num_trades_step,
+            "num_passive_fills_step": acc.num_passive_fills_step,
+            "order_step_placed": acc.order_step_placed,
+        })
+
+        # Reward decomposition (doc/11 2.4). The five signed contributions that
+        # sum to `reward`, so the variance split in doc/07 6.4 is measurable
+        # without re-deriving anything.
+        info["reward_terms"] = dict(acc.reward_terms)
+
+        # Market state (doc/11 2.2). Identical for every agent this step; it is
+        # repeated per agent because that is the shape RLlib gives `info`.
+        info.update({
+            "last_price": float(getattr(self, "last_price", 0.0)),
+            "best_bid": getattr(self, "best_bid", None),
+            "best_ask": getattr(self, "best_ask", None),
+            "spread": getattr(self, "spread", None),
+        })
+
+        # The action this agent actually submitted, as the model emitted it -
+        # before set_actions reshapes it for the LOB. Cleared at the end of
+        # step(), so it is live here but absent on any other call path.
+        model_actions = getattr(self, "model_actions", None) or {}
+        if agent_key in model_actions:
+            info["model_action"] = _plain(model_actions[agent_key])
+
+        # One conversion over the whole dict rather than per field. The counters
+        # and coefficients are a mix of Python and numpy scalars depending on
+        # where they came from, and np.int64 - unlike np.float64, which
+        # subclasses float - is not JSON serialisable. Converting at the exit
+        # means a field added later cannot reintroduce the problem.
+        infos[agent_key] = _plain(info)
 
         return infos

--- a/gym_continuousDoubleAuction/envs/exchg/info_helper.py
+++ b/gym_continuousDoubleAuction/envs/exchg/info_helper.py
@@ -20,6 +20,11 @@ def _plain(value):
     return value
 
 
+def _as_float(value):
+    """Decimal (or None) to float, for the JSON boundary. None passes through."""
+    return None if value is None else float(value)
+
+
 class Info_Helper(object):
 
     def set_info(self, infos, trader):
@@ -53,12 +58,10 @@ class Info_Helper(object):
         # Account state (doc/11 2.3). Read before set_step_outputs zeroes the
         # per-step counters, which happens after this call.
         info.update({
-            # float(), despite account.py initialising this to int 0: the
-            # position becomes a Decimal the moment a trade lands (account.py
-            # rebuilds it as Decimal +/- Decimal), so the type is int before the
-            # first fill and Decimal after. Contract counts are integral, so
-            # float loses nothing and the key holds one type all episode.
-            "net_position": float(acc.net_position),
+            # int, straight through: net_position is a count of contracts and
+            # the account now holds it as one for the whole episode, so there
+            # is nothing left here to paper over.
+            "net_position": acc.net_position,
             "VWAP": float(acc.VWAP),
             "cash": float(acc.cash),
             "cash_on_hold": float(acc.cash_on_hold),
@@ -77,11 +80,17 @@ class Info_Helper(object):
 
         # Market state (doc/11 2.2). Identical for every agent this step; it is
         # repeated per agent because that is the shape RLlib gives `info`.
+        #
+        # These are Decimal on the env and float here: `info` is a
+        # serialisation boundary, and JSON has no Decimal. NAV is the one field
+        # that pays the string cost to stay exact, because the conservation
+        # check depends on it; these are read for plots and diagnostics, where a
+        # float is both sufficient and directly usable. None stays None.
         info.update({
-            "last_price": float(getattr(self, "last_price", 0.0)),
-            "best_bid": getattr(self, "best_bid", None),
-            "best_ask": getattr(self, "best_ask", None),
-            "spread": getattr(self, "spread", None),
+            "last_price": _as_float(getattr(self, "last_price", None)),
+            "best_bid": _as_float(getattr(self, "best_bid", None)),
+            "best_ask": _as_float(getattr(self, "best_ask", None)),
+            "spread": _as_float(getattr(self, "spread", None)),
         })
 
         # The action this agent actually submitted, as the model emitted it -

--- a/gym_continuousDoubleAuction/envs/exchg/reward_helper.py
+++ b/gym_continuousDoubleAuction/envs/exchg/reward_helper.py
@@ -66,13 +66,38 @@ class Reward_Helper(object):
         current_drawdown = float(max(0, trader.acc.max_nav - trader.acc.nav))
         
         # 3. Comprehensive Reward Formula
-        reward = (nav_term 
-                  - (order_penalty * trader.acc.order_step_placed) 
-                  - (trade_penalty * trader.acc.num_trades_step) 
-                  - (drawdown_penalty * current_drawdown) 
-                  + (passive_bonus * trader.acc.num_passive_fills_step))
+        #
+        # Kept as the signed contribution of each term rather than a single
+        # expression, so the decomposition doc/07 6.4 asks to monitor is the
+        # same arithmetic the agent is actually trained on: accumulating the
+        # terms *is* the reward, and there is no second expression that could
+        # drift out of step with the logged split.
+        terms = {
+            "nav_term": nav_term,
+            "order_penalty": -(order_penalty * trader.acc.order_step_placed),
+            "trade_penalty": -(trade_penalty * trader.acc.num_trades_step),
+            "drawdown_penalty": -(drawdown_penalty * current_drawdown),
+            "passive_bonus": passive_bonus * trader.acc.num_passive_fills_step,
+        }
+
+        # Accumulated left to right, deliberately NOT with sum() or math.fsum().
+        # Instrumenting the reward must not change it, and on Python 3.12+ the
+        # builtin sum() applies Neumaier compensated summation to floats: it is
+        # more accurate, and it disagrees with this loop on ~44% of random
+        # inputs (~1e-13 relative). Insertion order matches the original
+        # formula and `a - b` is `a + (-b)` exactly in IEEE 754, so this
+        # reproduces the previous expression bit for bit. Iterating the dict
+        # rather than naming the five keys also means a term added later cannot
+        # be logged but left out of the reward.
+        reward = 0.0
+        for value in terms.values():
+            reward += value
 
         rewards[f'agent_{trader.ID}'] = reward
         trader.acc.reward = reward
+        trader.acc.reward_terms = terms
+        # The penalty uses the level, so the level is what is worth recording;
+        # it was previously computed here and thrown away (doc/11 2.3).
+        trader.acc.drawdown = current_drawdown
 
         return rewards

--- a/gym_continuousDoubleAuction/test/integration/test_progress_and_vf.py
+++ b/gym_continuousDoubleAuction/test/integration/test_progress_and_vf.py
@@ -1,0 +1,178 @@
+"""A real short run, checked for the two things a run used to leave no trace of.
+
+`test_progress_log.py` covers the writer and the metric extraction against a
+FakeAlgo whose results are hand-built. That leaves the assumption underneath
+both untested: that a *real* PPO iteration on this env actually produces a
+`learners` block containing `vf_explained_var` for each trainable module, and
+that a real result dict survives the JSON round trip. A rename in RLlib, or a
+result carrying something `_json_safe` cannot handle, would sail past the unit
+tests and leave the run logging nothing.
+
+So this builds an actual PPO and trains it, sized for speed rather than
+learning.
+
+What it asserts about the *value* of vf_explained_var is split in two, and the
+split is the point. `!= 0.0` looks like the obvious guard against a critic that
+never received a gradient, and it is worthless here: a run of this suite reports
+values around 1e-5 - the S1-1 signature doc/17 17.3 records from two real GPU
+runs as "0.0 to 1.8e-07" - and every one of them is nonzero, so the assertion
+passes on a critic that is comprehensively dead. Floating-point noise is not
+evidence of learning.
+
+So the unconditional assertions are only that the metric is present and finite
+(a diverged value loss really does show up as NaN, and that is worth catching),
+and the substantive claim - that the critic explains a non-trivial share of
+return variance - is a separate strict xfail. It fails today because S1-1 is
+open and unfixed. When S1-1 is fixed it will XPASS, which under strict xfail
+fails the build: that is deliberate, and the fix is to delete the marker,
+turning this into the live regression guard it cannot be while the defect is
+still there.
+"""
+import json
+import math
+import os
+import shutil
+import tempfile
+
+import pytest
+import ray
+
+from gym_continuousDoubleAuction.train.train import (
+    TrainConfig,
+    VF_EXPLAINED_VAR_KEY,
+    train,
+    vf_explained_var,
+)
+from gym_continuousDoubleAuction.train.policy.policy_handler import (
+    trainable_policy_ids,
+)
+
+NUM_ITERS = 3
+
+# Matches test_checkpoint_roundtrip.py: the smallest run that still exercises
+# the real learner path.
+TEST_CFG = dict(
+    num_agents=4,
+    num_trained_agents=2,
+    max_step=64,
+    num_episodes_per_iter=4,
+    num_epochs=1,
+    minibatch_size=64,
+    num_env_runners=0,
+    num_learners=0,
+    num_gpus_per_learner=0,
+    episode_data_dir=None,
+    log_level="ERROR",
+)
+
+
+class TestProgressAndCriticHealth:
+    """One real training run of a few iterations, then read what it left behind."""
+
+    @classmethod
+    def setup_class(cls):
+        ray.init(
+            ignore_reinit_error=True,
+            include_dashboard=False,
+            log_to_driver=False,
+            num_cpus=2,
+        )
+        cls.tmpdir = tempfile.mkdtemp(prefix="cda_progress_")
+        cls.cfg = TrainConfig(
+            log_base_dir=cls.tmpdir,
+            num_iters=NUM_ITERS,
+            chkpt_freq=0,
+            chkpt_keep=0,
+            **TEST_CFG,
+        )
+        cls.algo, cls.last_result = train(cls.cfg)
+
+        with open(cls.cfg.progress_path) as fh:
+            cls.lines = [json.loads(line) for line in fh if line.strip()]
+
+    @classmethod
+    def teardown_class(cls):
+        cls.algo.stop()
+        ray.shutdown()
+        shutil.rmtree(cls.tmpdir, ignore_errors=True)
+
+    def test_one_line_per_iteration(self):
+        assert os.path.isfile(self.cfg.progress_path)
+        assert len(self.lines) == NUM_ITERS
+        assert [line["training_iteration"] for line in self.lines] == list(
+            range(1, NUM_ITERS + 1)
+        )
+
+    def test_a_real_result_survives_the_json_round_trip(self):
+        """Parsing above already proved it; this pins what has to be *in* it.
+
+        A writer that silently dropped the nested blocks would still produce
+        parseable lines, so the assertion is that the metrics are there, not
+        merely that the file is valid JSON.
+        """
+        last = self.lines[-1]
+        assert last["env_runners"]["num_env_steps_sampled"] > 0
+        assert last["learners"], "the result carried no learner block"
+
+    def test_vf_explained_var_is_reported_for_every_trainable_module(self):
+        """The metric RLlib really emits, under the key this code really reads."""
+        expected = trainable_policy_ids(self.cfg.num_trained_agents)
+        reported = vf_explained_var(self.last_result, self.cfg)
+
+        assert sorted(reported) == sorted(expected), (
+            f"expected {VF_EXPLAINED_VAR_KEY} for {expected}, got "
+            f"{sorted(reported)}. If this is empty, RLlib has moved or renamed "
+            f"the key and the critic is no longer observable."
+        )
+
+    def test_the_metric_is_finite(self):
+        """A NaN here is a diverged value loss, which is a real regression.
+
+        This is the whole unconditional claim about the value - see the module
+        docstring, and `test_the_critic_actually_explains_something` below for
+        the claim that would mean the critic works.
+        """
+        for pid, value in vf_explained_var(self.last_result, self.cfg).items():
+            assert math.isfinite(value), (
+                f"{pid} reported a non-finite {VF_EXPLAINED_VAR_KEY} ({value}); "
+                f"the value loss has diverged"
+            )
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason=(
+            "S1-1: the critic receives no gradient, so vf_explained_var sits in "
+            "the 1e-5 noise floor. Fixing S1-1 makes this XPASS and fails the "
+            "build - remove the marker at that point, which turns this into the "
+            "regression guard it cannot be while the defect is open."
+        ),
+    )
+    def test_the_critic_actually_explains_something(self):
+        """The assertion that would have caught S1-1, pinned as a known failure.
+
+        The threshold is loose on purpose. `NUM_ITERS` iterations at this size
+        teach a *working* critic very little, so this is not a measure of how
+        well it learns - it is the line between "explains a share of the
+        variance" and "is indistinguishable from noise", which is the only
+        distinction a run this short can support.
+        """
+        reported = vf_explained_var(self.last_result, self.cfg)
+
+        noise = {
+            pid: value for pid, value in reported.items() if abs(value) < 1e-3
+        }
+        assert not noise, (
+            f"{VF_EXPLAINED_VAR_KEY} is in the noise floor for {sorted(noise)} "
+            f"after {NUM_ITERS} iterations ({noise}): the critic took no useful "
+            f"gradient, PPO degenerates to REINFORCE, and every advantage this "
+            f"run computes is noise. See doc/15 S1-1."
+        )
+
+    def test_the_file_carries_it_too(self):
+        """Not just the returned result: the on-disk record is the durable one."""
+        for pid in trainable_policy_ids(self.cfg.num_trained_agents):
+            values = [
+                line["learners"][pid][VF_EXPLAINED_VAR_KEY] for line in self.lines
+            ]
+            assert len(values) == NUM_ITERS
+            assert all(v is None or isinstance(v, float) for v in values), values

--- a/gym_continuousDoubleAuction/test/test_config_sources.py
+++ b/gym_continuousDoubleAuction/test/test_config_sources.py
@@ -47,6 +47,11 @@ def config_tree(tmp_path, monkeypatch):
 
     yield edit
 
+    # The env var has to go back *before* the cache is dropped, or the reload
+    # repopulates it from the modified tree and every later test in the session
+    # reads the edited values. monkeypatch would restore it on its own, but not
+    # until after this teardown has already run.
+    monkeypatch.delenv(config_loader.CONFIG_DIR_ENV_VAR, raising=False)
     config_loader.reload()
 
 
@@ -232,7 +237,18 @@ class TestStructuralConstantsComeFromTheFile:
         space = env.action_spaces["agent_0"]["size_mean"]
         assert (float(space.low[0]), float(space.high[0])) == (-2.0, 2.0)
 
-    def test_module_id_prefixes_come_from_the_file(self, config_tree):
+    def test_module_id_prefixes_come_from_the_file(self, config_tree, monkeypatch):
+        """`policy_handler` reads the prefixes once, at import.
+
+        That makes this the one test that has to put a *module* back, not just
+        the loader cache: `importlib.reload` re-executes policy_handler in its
+        own namespace, so POLICY_PREFIX stays at whatever the tree said until
+        something reloads it against the real one. Restoring the env var before
+        the reload is what makes that reload read the real one - leaving it set
+        pins `agent_` for the rest of the session, and anything later that
+        builds a ModuleID (`train.vf_explained_var`, for one) silently looks up
+        names no result will ever have.
+        """
         config_tree(
             "tunable_constants.json",
             lambda raw: raw["module_id_prefixes"].update(policy_prefix="agent_"),
@@ -242,8 +258,13 @@ class TestStructuralConstantsComeFromTheFile:
         try:
             assert ph.policy_id(0) == "agent_0"
         finally:
+            monkeypatch.delenv(config_loader.CONFIG_DIR_ENV_VAR, raising=False)
             config_loader.reload()
             importlib.reload(ph)
+
+        assert ph.policy_id(0) == "policy_0", (
+            "the prefix leaked out of this test and into the rest of the session"
+        )
 
     def test_price_anchor_fallbacks_are_read_once_for_both_users(self, config_tree):
         """The two fallbacks used to be independent literals that had to agree."""

--- a/gym_continuousDoubleAuction/test/test_info_dict.py
+++ b/gym_continuousDoubleAuction/test/test_info_dict.py
@@ -1,0 +1,301 @@
+"""What each step reports about itself.
+
+`info` used to carry three fields - reward, NAV, num_trades - so the state a
+run's behaviour is diagnosed from (position, drawdown, the spread, which of the
+five reward terms actually moved) existed for one step and was discarded. See
+doc/11 2.2-2.4.
+
+Two things here are invariants rather than descriptions, and they are the
+reason this file exists:
+
+  * the five reward terms sum to the reward, exactly. A decomposition that does
+    not add up is worse than none, because it looks authoritative.
+  * everything in `info` survives `json.dumps`. The per-iteration progress log
+    (doc/11 1.6) is the durable record, and a numpy scalar in `info` breaks it.
+"""
+import json
+import os
+import sys
+
+import pytest
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '../..')))
+
+from gym_continuousDoubleAuction.envs.continuousDoubleAuction_env import (
+    continuousDoubleAuctionEnv,
+)
+from gym_continuousDoubleAuction.envs.exchg.info_helper import _plain
+
+NUM_AGENTS = 4
+INIT_CASH = 1000000
+
+
+def _naive_sum(values):
+    """Left-to-right accumulation.
+
+    Deliberately not `sum()`: on Python 3.12+ the builtin applies Neumaier
+    compensated summation to floats, which disagrees with plain accumulation in
+    the last bits. The reward is built by accumulation, so that is what the
+    invariant has to be checked against - using `sum()` here would make this
+    test fail on arithmetic that is correct.
+    """
+    total = 0.0
+    for value in values:
+        total += value
+    return total
+
+
+@pytest.fixture(scope="module")
+def stepped_env():
+    """A real env driven far enough that positions, trades and fills exist."""
+    env = continuousDoubleAuctionEnv({
+        "num_of_agents": NUM_AGENTS,
+        "init_cash": INIT_CASH,
+        "tick_size": 1,
+        "tape_display_length": 10,
+        "max_step": 100,
+    })
+    env.reset()
+    last_infos, last_rewards = {}, {}
+    every_info = []
+    for _ in range(40):
+        actions = {
+            f"agent_{i}": env.action_spaces[f"agent_{i}"].sample()
+            for i in range(NUM_AGENTS)
+        }
+        _, rewards, terminateds, truncateds, infos = env.step(actions)
+        last_infos, last_rewards = infos, rewards
+        every_info.append(infos)
+        if terminateds.get("__all__") or truncateds.get("__all__"):
+            break
+    return env, last_infos, last_rewards, every_info
+
+
+class TestBackCompat:
+    """The three original fields are unchanged - name, type and meaning."""
+
+    def test_the_original_three_fields_survive(self, stepped_env):
+        _, infos, _, _ = stepped_env
+        for i in range(NUM_AGENTS):
+            info = infos[f"agent_{i}"]
+            assert {"reward", "NAV", "num_trades"} <= set(info)
+            assert isinstance(info["num_trades"], int)
+
+    def test_nav_is_still_a_string(self, stepped_env):
+        """Not cosmetic: the conservation check parses it back with Decimal and
+        visualize_nav.py with float(). Both need the exact str() of a Decimal."""
+        env, infos, _, _ = stepped_env
+        for i in range(NUM_AGENTS):
+            reported = infos[f"agent_{i}"]["NAV"]
+            assert isinstance(reported, str)
+            assert reported == str(env.traders[i].acc.nav)
+
+    def test_reward_matches_the_rewards_dict(self, stepped_env):
+        _, infos, rewards, _ = stepped_env
+        for i in range(NUM_AGENTS):
+            assert infos[f"agent_{i}"]["reward"] == rewards[f"agent_{i}"]
+
+
+class TestRewardDecomposition:
+    """doc/11 2.4: the five terms, individually, and they must add up."""
+
+    def test_all_five_terms_are_reported(self, stepped_env):
+        _, infos, _, _ = stepped_env
+        expected = {
+            "nav_term", "order_penalty", "trade_penalty",
+            "drawdown_penalty", "passive_bonus",
+        }
+        for i in range(NUM_AGENTS):
+            assert set(infos[f"agent_{i}"]["reward_terms"]) == expected
+
+    def test_the_terms_sum_to_the_reward_exactly(self, stepped_env):
+        """The invariant. Not approx: the reward *is* this accumulation, so any
+        difference means the logged split is not what the agent was trained on."""
+        _, infos, _, _ = stepped_env
+        for i in range(NUM_AGENTS):
+            info = infos[f"agent_{i}"]
+            assert _naive_sum(info["reward_terms"].values()) == info["reward"]
+
+    def test_the_terms_match_the_documented_formula(self, stepped_env):
+        """Reward = nav_term - order - trade - drawdown + passive (doc/07 6).
+
+        Rebuilt from the env's own coefficients and counters, so this catches a
+        term being recorded with the wrong sign or against the wrong counter -
+        which summing alone would not.
+        """
+        env, infos, _, _ = stepped_env
+        for i in range(NUM_AGENTS):
+            terms = infos[f"agent_{i}"]["reward_terms"]
+            assert terms["order_penalty"] <= 0
+            assert terms["trade_penalty"] <= 0
+            assert terms["drawdown_penalty"] <= 0
+            assert terms["passive_bonus"] >= 0
+
+    def test_signs_follow_the_penalty_coefficients(self, stepped_env):
+        """A penalty that fired must be exactly coefficient x counter."""
+        env, infos, _, _ = stepped_env
+        for i in range(NUM_AGENTS):
+            info = infos[f"agent_{i}"]
+            terms = info["reward_terms"]
+            assert terms["order_penalty"] == pytest.approx(
+                -(env.order_penalty * info["order_step_placed"])
+            )
+            assert terms["trade_penalty"] == pytest.approx(
+                -(env.trade_penalty * info["num_trades_step"])
+            )
+            assert terms["passive_bonus"] == pytest.approx(
+                env.passive_bonus * info["num_passive_fills_step"]
+            )
+
+
+class TestAccountState:
+    """doc/11 2.3."""
+
+    def test_the_account_fields_are_present(self, stepped_env):
+        _, infos, _, _ = stepped_env
+        expected = {
+            "net_position", "VWAP", "cash", "cash_on_hold", "position_val",
+            "drawdown", "max_nav", "num_trades_step",
+            "num_passive_fills_step", "order_step_placed",
+        }
+        for i in range(NUM_AGENTS):
+            assert expected <= set(infos[f"agent_{i}"])
+
+    def test_net_position_holds_one_type_across_the_episode(self, stepped_env):
+        """account.py starts it as int 0 and rebuilds it as a Decimal on the
+        first fill. The reported field must not change type underneath a
+        consumer partway through an episode."""
+        _, infos, _, _ = stepped_env
+        for i in range(NUM_AGENTS):
+            assert isinstance(infos[f"agent_{i}"]["net_position"], float)
+
+    def test_drawdown_is_the_level_the_penalty_uses(self, stepped_env):
+        """max_nav - nav, floored at 0 - computed in reward_helper and, before
+        this, thrown away."""
+        env, infos, _, _ = stepped_env
+        for i in range(NUM_AGENTS):
+            acc = env.traders[i].acc
+            expected = float(max(0, acc.max_nav - acc.nav))
+            assert infos[f"agent_{i}"]["drawdown"] == pytest.approx(expected)
+
+    def test_the_per_step_counters_are_read_before_they_are_zeroed(self, stepped_env):
+        """set_step_outputs zeroes these right after set_info.
+
+        Asserting the type would not catch the failure that matters: if the
+        ordering ever flips, every counter still reports a perfectly valid int,
+        just always 0. So this requires the counters to have been observed
+        non-zero at some point across the episode - which is only possible if
+        they are read while still live.
+        """
+        _, _, _, every_info = stepped_env
+        assert every_info, "fixture stepped no episodes"
+
+        for key in ("num_trades_step", "num_passive_fills_step",
+                    "order_step_placed"):
+            observed = [
+                infos[f"agent_{i}"][key]
+                for infos in every_info
+                for i in range(NUM_AGENTS)
+            ]
+            assert all(isinstance(v, int) for v in observed)
+            assert any(v != 0 for v in observed), (
+                f"{key} was 0 on every step of every agent: set_info is "
+                f"probably running after the counters are reset, which would "
+                f"log a constant 0 while looking healthy"
+            )
+
+
+class TestMarketState:
+    """doc/11 2.2."""
+
+    def test_market_fields_are_present_and_shared(self, stepped_env):
+        """Same book for everyone, so every agent must report the same view."""
+        _, infos, _, _ = stepped_env
+        for key in ("last_price", "best_bid", "best_ask", "spread"):
+            values = [infos[f"agent_{i}"][key] for i in range(NUM_AGENTS)]
+            assert len(set(values)) == 1, f"{key} differs between agents"
+
+    def test_spread_is_the_touch_difference(self, stepped_env):
+        _, infos, _, _ = stepped_env
+        info = infos["agent_0"]
+        if info["best_bid"] is not None and info["best_ask"] is not None:
+            assert info["spread"] == pytest.approx(
+                info["best_ask"] - info["best_bid"]
+            )
+        else:
+            assert info["spread"] is None
+
+    def test_a_one_sided_book_reports_none_not_zero(self):
+        """0.0 would be indistinguishable from a book whose touch is touching.
+        The observation needs a finite sentinel; a log does not (doc/15 S3-14).
+        """
+        class FakeTree:
+            def __init__(self, price):
+                self.price = price
+
+            def max_price(self):
+                return self.price
+
+            def min_price(self):
+                return self.price
+
+        class FakeLOB:
+            def __init__(self, bid, ask):
+                self.bids = FakeTree(bid)
+                self.asks = FakeTree(ask)
+
+            def get_best_bid(self):
+                return self.bids.max_price()
+
+            def get_best_ask(self):
+                return self.asks.min_price()
+
+        from gym_continuousDoubleAuction.envs.exchg.exchg_helper import Exchg_Helper
+
+        for bid, ask in ((None, None), (10, None), (None, 12)):
+            exchange = Exchg_Helper.__new__(Exchg_Helper)
+            exchange.LOB = FakeLOB(bid, ask)
+            exchange.set_market_snapshot()
+            assert exchange.spread is None, f"bid={bid} ask={ask}"
+
+        exchange = Exchg_Helper.__new__(Exchg_Helper)
+        exchange.LOB = FakeLOB(10, 12)
+        exchange.set_market_snapshot()
+        assert exchange.spread == 2.0
+
+
+class TestSerialisation:
+    """The progress log is the durable record; `info` has to fit through it."""
+
+    def test_the_whole_info_dict_survives_json(self, stepped_env):
+        _, infos, _, _ = stepped_env
+        assert json.loads(json.dumps(infos)) is not None
+
+    def test_the_model_action_is_reported_and_plain(self, stepped_env):
+        """Actions arrive as numpy scalars and arrays; np.int64 is not JSON
+        serialisable, unlike np.float64 which subclasses float."""
+        _, infos, _, _ = stepped_env
+        for i in range(NUM_AGENTS):
+            assert "model_action" in infos[f"agent_{i}"]
+        json.dumps(infos["agent_0"]["model_action"])
+
+    def test_plain_converts_nested_numpy(self):
+        import numpy as np
+
+        converted = _plain({
+            "i": np.int64(3),
+            "f": np.float32(1.5),
+            "arr": np.array([1, 2], dtype=np.int64),
+            "nested": {"deep": np.int32(7)},
+            "tup": (np.int64(1), "s"),
+        })
+        json.dumps(converted)
+        assert converted["i"] == 3
+        assert converted["arr"] == [1, 2]
+        assert converted["nested"]["deep"] == 7
+        assert converted["tup"] == [1, "s"]
+
+    def test_plain_leaves_ordinary_values_alone(self):
+        assert _plain("1000.5") == "1000.5"
+        assert _plain(None) is None
+        assert _plain(3) == 3

--- a/gym_continuousDoubleAuction/test/test_info_dict.py
+++ b/gym_continuousDoubleAuction/test/test_info_dict.py
@@ -161,13 +161,20 @@ class TestAccountState:
         for i in range(NUM_AGENTS):
             assert expected <= set(infos[f"agent_{i}"])
 
-    def test_net_position_holds_one_type_across_the_episode(self, stepped_env):
-        """account.py starts it as int 0 and rebuilds it as a Decimal on the
-        first fill. The reported field must not change type underneath a
-        consumer partway through an episode."""
-        _, infos, _, _ = stepped_env
-        for i in range(NUM_AGENTS):
-            assert isinstance(infos[f"agent_{i}"]["net_position"], float)
+    def test_net_position_is_an_int_across_the_episode(self, stepped_env):
+        """A net position is a count of contracts, so it is an int - before the
+        first fill and after it.
+
+        This used to be reported as a float purely to paper over the account
+        rebuilding the field as a Decimal on the first trade. The account now
+        keeps it in int, so the cast is gone and the type is the real one.
+        """
+        _, _, _, every_info = stepped_env
+        for infos in every_info:
+            for i in range(NUM_AGENTS):
+                value = infos[f"agent_{i}"]["net_position"]
+                assert isinstance(value, int), f"{value!r} is {type(value).__name__}"
+                assert not isinstance(value, bool)
 
     def test_drawdown_is_the_level_the_penalty_uses(self, stepped_env):
         """max_nav - nav, floored at 0 - computed in reward_helper and, before

--- a/gym_continuousDoubleAuction/test/test_nav_callback.py
+++ b/gym_continuousDoubleAuction/test/test_nav_callback.py
@@ -12,6 +12,7 @@ is now under test. See doc/11_logging_and_observability.md.
 import logging
 import sys
 import os
+from decimal import Decimal
 from unittest.mock import MagicMock
 
 import pytest
@@ -119,7 +120,9 @@ class TestNAVCallback:
         assert any(r.levelno == logging.ERROR for r in caplog.records)
 
     def test_tolerance_admits_a_difference_below_it(self):
-        """The tolerance absorbs the float() round trip, nothing larger."""
+        """The tolerance is headroom for real cash leaving the system, not
+        arithmetic slack: the check is Decimal end to end, so it is what
+        separates a legitimate difference from a corrupt ledger."""
         drift = 0.001
         per_agent = self.init_cash + drift / self.num_agents
 
@@ -129,6 +132,65 @@ class TestNAVCallback:
         strict = self._callback(nav_tolerance=1e-9)
         with pytest.raises(AssertionError):
             self._end_episode(strict, "ep_outside", per_agent)
+
+    def test_a_breach_is_caught_at_an_account_size_float_cannot_resolve(self):
+        """The check must be Decimal end to end, not float.
+
+        At init_cash 1e15 the spacing between adjacent floats near the total is
+        0.5, so a real quarter-dollar of destroyed cash rounds to exactly 0.0 -
+        the old float() round trip reported perfect conservation and the run
+        continued on a corrupt ledger. Decimal sees the 0.25. The cliff is at
+        roughly init_cash 1e10; see doc/16 §16.10.
+        """
+        self.init_cash = 10 ** 15
+        self.mock_env = MockEnv(self.init_cash, self.num_agents)
+        callback = self._callback()
+        metrics = MagicMock()
+
+        # 0.0625 short per agent = 0.25 destroyed across the four of them.
+        info = {
+            f"agent_{i}": {"NAV": str(Decimal(self.init_cash) - Decimal("0.0625"))}
+            for i in range(self.num_agents)
+        }
+        with pytest.raises(AssertionError, match="NAV conservation VIOLATED"):
+            callback.on_episode_end(
+                episode=MockEpisode("ep_large", info),
+                env_runner=self.mock_runner,
+                metrics_logger=metrics,
+                env=self.mock_env,
+                env_index=0,
+                rl_module=None,
+            )
+
+        metrics.log_value.assert_called_once_with(
+            "nav_conservation_error", pytest.approx(0.25), window=1
+        )
+
+    def test_conservation_error_is_exactly_zero_not_merely_close(self):
+        """Decimal end to end means the expected error is 0, so a tolerance of
+        0 is a usable setting rather than an impossible one."""
+        callback = self._callback(nav_tolerance=0.0)
+        metrics = MagicMock()
+
+        # Long fractional tails that cancel exactly - what the ledger produces.
+        tails = ["0.000000000000000000001", "-0.000000000000000000001",
+                 "0.000000000000000000002", "-0.000000000000000000002"]
+        info = {
+            f"agent_{i}": {"NAV": str(Decimal(self.init_cash) + Decimal(t))}
+            for i, t in enumerate(tails)
+        }
+        callback.on_episode_end(
+            episode=MockEpisode("ep_exact", info),
+            env_runner=self.mock_runner,
+            metrics_logger=metrics,
+            env=self.mock_env,
+            env_index=0,
+            rl_module=None,
+        )
+
+        metrics.log_value.assert_called_once_with(
+            "nav_conservation_error", 0.0, window=1
+        )
 
     def test_config_supplies_the_defaults(self):
         """Neither knob is a literal in the callback."""

--- a/gym_continuousDoubleAuction/test/test_progress_log.py
+++ b/gym_continuousDoubleAuction/test/test_progress_log.py
@@ -1,0 +1,300 @@
+"""The per-iteration `progress.jsonl` record, and what it does with awkward values.
+
+`algo.train()` returns a full metrics dict every iteration. The driver loop used
+to pull two keys out of it for a log line and drop the rest, so a finished run
+left behind checkpoints, a scrollback of log lines, and no machine-readable
+record of how it got there - there was no `results/progress.jsonl` and no Tune
+`progress.csv`, because the loop calls `algo.train()` directly rather than going
+through a Tuner. These tests pin the record.
+
+The awkward values matter as much as the happy path. RLlib results carry numpy
+scalars and arrays, occasionally an object with no JSON form, and NaNs early in
+a run; a logger that raised on any of those would take down a training run that
+was otherwise fine. See doc/11 2.1.
+"""
+import dataclasses
+import json
+import logging
+import os
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from gym_continuousDoubleAuction.logging_setup import ROOT_NAME as LOGGER
+from gym_continuousDoubleAuction.train import train as train_mod
+from gym_continuousDoubleAuction.train.train import (
+    PROGRESS_FILE,
+    TrainConfig,
+    VF_EXPLAINED_VAR_KEY,
+    _append_progress,
+    _json_safe,
+    train,
+    vf_explained_var,
+)
+
+
+def _learner_block(**per_module):
+    """A result's `learners` block, keyed the way RLlib keys it."""
+    from ray.rllib.utils.metrics import LEARNER_RESULTS
+
+    return {LEARNER_RESULTS: dict(per_module)}
+
+
+class FakeAlgo:
+    """Enough of an Algorithm to drive the loop, returning a realistic result.
+
+    The result deliberately carries numpy types and a learner block: a fake that
+    returned only plain floats would pass a JSON writer that cannot actually
+    survive an RLlib result.
+    """
+
+    def __init__(self, start_iteration=0, vf_values=(0.42, 0.31)):
+        self.iteration = start_iteration
+        self.callbacks = []
+        self.vf_values = vf_values
+
+    def train(self):
+        self.iteration += 1
+        result = {
+            "training_iteration": self.iteration,
+            "env_runners": {
+                "num_env_steps_sampled": np.int64(256),
+                "module_episode_returns_mean": {"policy_0": np.float32(1.5)},
+            },
+        }
+        result.update(_learner_block(**{
+            f"policy_{i}": {VF_EXPLAINED_VAR_KEY: np.float32(v)}
+            for i, v in enumerate(self.vf_values)
+        }))
+        return result
+
+    def save(self, path):
+        os.makedirs(path, exist_ok=True)
+        with open(os.path.join(path, "rllib_checkpoint.json"), "w") as fh:
+            json.dump({"marker": str(self.iteration)}, fh)
+        return path
+
+
+@pytest.fixture
+def cfg(tmp_path):
+    return TrainConfig(
+        log_base_dir=str(tmp_path / "results"),
+        num_trained_agents=2,
+        num_agents=4,
+        chkpt_freq=0,
+    )
+
+
+@pytest.fixture
+def looped(cfg, monkeypatch):
+    """`train()` with the algorithm build stubbed out, for a given iteration count."""
+
+    def run(num_iters, algo=None):
+        algo = algo if algo is not None else FakeAlgo()
+        monkeypatch.setattr(train_mod, "build_algo", lambda _cfg: (algo, None))
+        train(dataclasses.replace(cfg, num_iters=num_iters))
+        return algo
+
+    return run
+
+
+def _lines(cfg):
+    with open(cfg.progress_path) as fh:
+        return [json.loads(line) for line in fh if line.strip()]
+
+
+class TestProgressFile:
+    """Where the file lands and what a run writes into it."""
+
+    def test_it_sits_beside_the_checkpoints(self, cfg):
+        """Under log_base_dir, so a runtime profile that redirects results moves it."""
+        assert cfg.progress_path == os.path.join(
+            os.path.abspath(cfg.log_base_dir), PROGRESS_FILE
+        )
+        assert os.path.dirname(cfg.progress_path) == os.path.dirname(
+            cfg.checkpoint_dir
+        )
+
+    def test_one_line_per_iteration(self, cfg, looped):
+        looped(4)
+
+        lines = _lines(cfg)
+        assert len(lines) == 4
+        assert [line["training_iteration"] for line in lines] == [1, 2, 3, 4]
+
+    def test_a_second_run_appends_rather_than_truncating(self, cfg, looped):
+        """A resumed run must not erase the history it is resuming from."""
+        looped(2)
+        looped(4, algo=FakeAlgo(start_iteration=2))
+
+        assert [line["training_iteration"] for line in _lines(cfg)] == [1, 2, 3, 4]
+
+    def test_the_whole_result_is_kept_not_just_the_logged_keys(self, cfg, looped):
+        """The point of the file: the metrics the log line does not print.
+
+        `_log_iteration` shows returns and vf_explained_var. Everything else
+        RLlib computed - loss terms, KL, entropy, timers - is only ever in here.
+        """
+        looped(1)
+
+        line = _lines(cfg)[0]
+        assert line["env_runners"]["num_env_steps_sampled"] == 256
+        assert line["learners"]["policy_0"][VF_EXPLAINED_VAR_KEY] == pytest.approx(0.42)
+
+    def test_numbers_survive_as_numbers(self, cfg, looped):
+        """numpy scalars must not arrive as quoted strings.
+
+        A bare `json.dump(..., default=str)` would write "256" and "1.5", and
+        every consumer would have to parse them back.
+        """
+        looped(1)
+
+        env_runners = _lines(cfg)[0]["env_runners"]
+        assert isinstance(env_runners["num_env_steps_sampled"], int)
+        assert isinstance(env_runners["module_episode_returns_mean"]["policy_0"], float)
+
+
+class TestAwkwardValues:
+    """What `_json_safe` does with the things RLlib actually puts in a result."""
+
+    def test_numpy_scalars_and_arrays(self):
+        assert _json_safe(np.float32(1.5)) == 1.5
+        assert _json_safe(np.int64(7)) == 7
+        assert _json_safe(np.bool_(True)) is True
+        assert _json_safe(np.array([1.0, 2.0])) == [1.0, 2.0]
+
+    def test_non_finite_floats_become_null(self):
+        """NaN and Infinity are not valid JSON, however happily Python emits them.
+
+        An untrained critic's vf_explained_var is legitimately NaN, so this is a
+        normal early-iteration value, not a corrupt one.
+        """
+        assert _json_safe(float("nan")) is None
+        assert _json_safe(float("inf")) is None
+        assert _json_safe({"vf": np.float32("nan")}) == {"vf": None}
+
+    def test_an_object_with_no_json_form_is_stringified(self):
+        assert _json_safe(SimpleNamespace(a=1)).startswith("namespace(")
+
+    def test_non_string_dict_keys_are_coerced(self):
+        assert _json_safe({1: "a"}) == {"1": "a"}
+
+    def test_the_output_is_strictly_parseable(self, cfg):
+        """The whole contract: whatever went in, strict JSON comes out.
+
+        `parse_constant` fires on NaN/Infinity/-Infinity, which a plain
+        `json.dump` would happily emit and a strict reader would reject.
+        """
+        _append_progress(
+            {
+                "arr": np.arange(3),
+                "nan": float("nan"),
+                "obj": SimpleNamespace(a=1),
+                "nested": {"tup": (np.float64(1.0), None, True)},
+            },
+            cfg,
+        )
+
+        with open(cfg.progress_path) as fh:
+            written = fh.read()
+
+        parsed = json.loads(written, parse_constant=_reject)
+        assert parsed["arr"] == [0, 1, 2]
+        assert parsed["nan"] is None
+        assert parsed["nested"]["tup"] == [1.0, None, True]
+        assert isinstance(parsed["obj"], str)
+
+
+def _reject(constant):
+    raise AssertionError(f"non-JSON constant {constant!r} was written")
+
+
+class TestFailuresDoNotStopTraining:
+    """Instrumentation must never be the thing that kills a run."""
+
+    def test_an_unwritable_path_warns_and_carries_on(self, cfg, caplog, monkeypatch):
+        def explode(*_args, **_kwargs):
+            raise OSError("No space left on device")
+
+        monkeypatch.setattr(train_mod, "open", explode, raising=False)
+
+        with caplog.at_level(logging.WARNING, logger=LOGGER):
+            _append_progress({"training_iteration": 1}, cfg)
+
+        assert "could not append" in caplog.text
+
+    def test_the_loop_finishes_even_when_every_write_fails(self, cfg, monkeypatch, looped):
+        monkeypatch.setattr(
+            train_mod, "_json_safe",
+            lambda _r: (_ for _ in ()).throw(RuntimeError("unserialisable")),
+        )
+
+        algo = looped(3)
+
+        assert algo.iteration == 3, "a logging failure stopped the training loop"
+
+
+class TestVfExplainedVar:
+    """The critic-health metric pulled out of the learner block."""
+
+    def test_read_for_every_trainable_module(self, cfg):
+        result = _learner_block(
+            policy_0={VF_EXPLAINED_VAR_KEY: 0.5},
+            policy_1={VF_EXPLAINED_VAR_KEY: 0.25},
+        )
+
+        assert vf_explained_var(result, cfg) == {"policy_0": 0.5, "policy_1": 0.25}
+
+    def test_frozen_modules_are_not_expected(self, cfg):
+        """Champions and random baselines never appear in the learner block.
+
+        They are not in `policies_to_train`, so RLlib computes no learner stats
+        for them. Asking for them would be asking for a KeyError.
+        """
+        result = _learner_block(
+            policy_0={VF_EXPLAINED_VAR_KEY: 0.5},
+            policy_1={VF_EXPLAINED_VAR_KEY: 0.25},
+            policy_2={VF_EXPLAINED_VAR_KEY: 0.0},
+            champion_v1={VF_EXPLAINED_VAR_KEY: 0.0},
+        )
+
+        assert sorted(vf_explained_var(result, cfg)) == ["policy_0", "policy_1"]
+
+    def test_a_missing_module_is_omitted_not_zeroed(self, cfg):
+        """Absent and "explains nothing" are different, and 0.0 is the alarm."""
+        result = _learner_block(policy_0={VF_EXPLAINED_VAR_KEY: 0.5})
+
+        assert vf_explained_var(result, cfg) == {"policy_0": 0.5}
+
+    def test_a_result_without_a_learner_block_is_empty_not_an_error(self, cfg):
+        assert vf_explained_var({}, cfg) == {}
+        assert vf_explained_var({"learners": None}, cfg) == {}
+
+    def test_it_reaches_the_iteration_log_line(self, cfg, caplog, looped):
+        with caplog.at_level(logging.INFO, logger=LOGGER):
+            looped(1)
+
+        assert "vf_explained_var" in caplog.text
+        assert "policy_0=0.42" in caplog.text
+
+    def test_the_log_line_does_not_round_a_dead_critic_to_zero(self, cfg, caplog, looped):
+        """3 significant figures, not 3 decimals.
+
+        The values this metric takes on a broken run are ~1e-5 (see doc/17
+        17.3), and `round(3.8e-05, 3)` is `0.0` - which prints identically to a
+        module that reported nothing, losing the distinction the metric exists
+        to draw.
+        """
+        with caplog.at_level(logging.INFO, logger=LOGGER):
+            looped(1, algo=FakeAlgo(vf_values=(3.82e-05, -1.25e-05)))
+
+        assert "policy_0=3.82e-05" in caplog.text
+        assert "policy_0=0.0" not in caplog.text
+
+    def test_a_result_with_no_learner_stats_says_so(self, cfg, caplog, looped):
+        """An empty dict in the log line reads as "all zero"; "n/a" does not."""
+        with caplog.at_level(logging.INFO, logger=LOGGER):
+            looped(1, algo=FakeAlgo(vf_values=()))
+
+        assert "vf_explained_var: n/a" in caplog.text

--- a/gym_continuousDoubleAuction/test/test_type_policy.py
+++ b/gym_continuousDoubleAuction/test/test_type_policy.py
@@ -1,0 +1,244 @@
+"""The ledger's type policy, enforced rather than assumed.
+
+    prices    -> Decimal
+    money     -> Decimal
+    sizes     -> int
+    signals   -> float   (reward and drawdown; RLlib requires float rewards)
+
+The point is not tidiness. Two concrete failures motivated it:
+
+  * `Decimal * float` raises TypeError, while `Decimal * int` is fine. The
+    orderbook carries two local workarounds for exactly that error
+    (`orderbook.py:76-79` and `:99-100`, both commented with the traceback),
+    and `cash_processor.py:78` would raise it on the modify path.
+  * A field that changes type partway through an episode breaks every consumer
+    that checks it. `net_position` was int until the first fill and Decimal
+    after; `VWAP` was Decimal until a position went flat and int after.
+
+Code in `envs/orderbook/` is deliberately not changed (doc/11 1.8). It stores
+sizes as Decimal internally, so the boundary is normalised on the way out by
+`trader._normalise_trade_sizes` - these tests pin that boundary, since it is
+what makes the policy hold everywhere else.
+"""
+import os
+import sys
+from decimal import Decimal
+
+import pytest
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '../..')))
+
+from gym_continuousDoubleAuction.envs.continuousDoubleAuction_env import (
+    continuousDoubleAuctionEnv,
+)
+from gym_continuousDoubleAuction.envs.agent.trader import _normalise_trade_sizes
+
+NUM_AGENTS = 4
+INIT_CASH = 1000000
+
+MONEY_FIELDS = ["cash", "cash_on_hold", "position_val", "init_nav", "nav",
+                "prev_nav", "max_nav", "profit", "total_profit"]
+PRICE_FIELDS = ["VWAP"]
+SIZE_FIELDS = ["net_position", "num_trades", "num_trades_step",
+               "num_passive_fills_step", "order_step_placed"]
+SIGNAL_FIELDS = ["reward", "drawdown"]
+
+
+@pytest.fixture(scope="module")
+def stepped_env():
+    env = continuousDoubleAuctionEnv({
+        "num_of_agents": NUM_AGENTS,
+        "init_cash": INIT_CASH,
+        "tick_size": 1,
+        "tape_display_length": 100000,
+        "max_step": 100,
+    })
+    env.reset()
+    snapshots = []
+    for _ in range(40):
+        actions = {
+            f"agent_{i}": env.action_spaces[f"agent_{i}"].sample()
+            for i in range(NUM_AGENTS)
+        }
+        _, _, terminateds, truncateds, _ = env.step(actions)
+        snapshots.append([
+            {f: getattr(t.acc, f) for f in
+             MONEY_FIELDS + PRICE_FIELDS + SIZE_FIELDS + SIGNAL_FIELDS}
+            for t in env.traders
+        ])
+        if terminateds.get("__all__") or truncateds.get("__all__"):
+            break
+    return env, snapshots
+
+
+def _every(snapshots, fields):
+    for step in snapshots:
+        for acc in step:
+            for field in fields:
+                yield field, acc[field]
+
+
+class TestAccountTypes:
+
+    def test_money_is_decimal(self, stepped_env):
+        _, snapshots = stepped_env
+        for field, value in _every(snapshots, MONEY_FIELDS):
+            assert isinstance(value, Decimal), (
+                f"{field} is {type(value).__name__}: money must be Decimal"
+            )
+
+    def test_prices_are_decimal(self, stepped_env):
+        """VWAP is an average fill price. It used to be assigned a bare 0 when a
+        position went flat, so it read back as an int for the rest of the run."""
+        _, snapshots = stepped_env
+        for field, value in _every(snapshots, PRICE_FIELDS):
+            assert isinstance(value, Decimal), (
+                f"{field} is {type(value).__name__}: prices must be Decimal"
+            )
+
+    def test_sizes_are_int(self, stepped_env):
+        _, snapshots = stepped_env
+        for field, value in _every(snapshots, SIZE_FIELDS):
+            assert isinstance(value, int) and not isinstance(value, bool), (
+                f"{field} is {type(value).__name__}: sizes must be int"
+            )
+
+    def test_learning_signals_are_float(self, stepped_env):
+        """The deliberate exception: RLlib requires float rewards, and drawdown
+        feeds the reward. These are signals, not money."""
+        _, snapshots = stepped_env
+        for field, value in _every(snapshots, SIGNAL_FIELDS):
+            assert isinstance(value, float), (
+                f"{field} is {type(value).__name__}: signals must be float"
+            )
+
+    def test_no_field_changes_type_across_the_episode(self, stepped_env):
+        """The failure this policy exists to prevent: a field whose type depends
+        on whether a trade has happened yet."""
+        _, snapshots = stepped_env
+        types = {}
+        for field, value in _every(
+            snapshots, MONEY_FIELDS + PRICE_FIELDS + SIZE_FIELDS + SIGNAL_FIELDS
+        ):
+            types.setdefault(field, set()).add(type(value).__name__)
+        unstable = {f: t for f, t in types.items() if len(t) > 1}
+        assert not unstable, f"fields changing type mid-episode: {unstable}"
+
+
+class TestBookBoundary:
+    """The orderbook is untouched, so its output is normalised on the way out."""
+
+    def test_prices_out_of_the_book_are_decimal(self, stepped_env):
+        env, _ = stepped_env
+        assert env.LOB.tape, "no trades on the tape"
+        for entry in env.LOB.tape:
+            assert isinstance(entry["price"], Decimal)
+
+    def test_sizes_reaching_the_account_are_int(self, stepped_env):
+        """What the account consumes, after normalisation - not what the book
+        stores internally, which stays Decimal and is not our business."""
+        env, _ = stepped_env
+        for entry in env.LOB.tape:
+            assert Decimal(str(entry["quantity"])) % 1 == 0, (
+                "a non-integral size would make the int() coercion at the "
+                "boundary a silent truncation"
+            )
+
+    def test_normalise_converts_decimal_sizes(self):
+        trades = [
+            {"quantity": Decimal("35"), "price": Decimal("10")},
+            {"quantity": 12, "price": Decimal("10")},
+        ]
+        _normalise_trade_sizes(trades)
+        assert [t["quantity"] for t in trades] == [35, 12]
+        assert all(isinstance(t["quantity"], int) for t in trades)
+
+    def test_normalise_refuses_a_fractional_size(self):
+        """Silent truncation would corrupt the ledger; this must be loud."""
+        with pytest.raises(ValueError, match="non-integral trade size"):
+            _normalise_trade_sizes([{"quantity": Decimal("1.5")}])
+
+    def test_normalise_tolerates_a_trade_without_a_size(self):
+        trades = [{"price": Decimal("10")}]
+        _normalise_trade_sizes(trades)
+        assert "quantity" not in trades[0]
+
+
+class TestBookIngress:
+    """Sizes must be int *going in*, not only coming back out.
+
+    These exist because of a mutation test: restoring the old
+    `(size + min_size) * 1.0` float coercion in action_helper left every other
+    test in this file passing. `_normalise_trade_sizes` absorbs float sizes on
+    the way out so completely that the account never notices - which is good,
+    but it means the egress tests cannot see an ingress regression.
+
+    Ingress matters on its own: `cash_processor.py:78` computes
+    `Decimal(str(price)) * qoute['quantity']` on the modify path, which is a
+    TypeError with a float size and fine with an int. That path is not reached
+    by the trades the egress tests inspect.
+    """
+
+    def test_set_actions_emits_int_sizes(self, stepped_env):
+        env, _ = stepped_env
+        model_outs = {
+            f"agent_{i}": env.action_spaces[f"agent_{i}"].sample()
+            for i in range(NUM_AGENTS)
+        }
+        for act in env.set_actions(model_outs):
+            size = act["size"]
+            assert isinstance(size, int) and not isinstance(size, bool), (
+                f"size {size!r} is {type(size).__name__}: sizes must enter the "
+                f"book as int, or cash_processor's modify path raises TypeError"
+            )
+
+    def test_sizes_reaching_the_book_are_int(self, stepped_env):
+        """Wrap the book's front door and check every order that arrives."""
+        env, _ = stepped_env
+        seen = []
+        original = env.LOB.process_order
+
+        def recording(quote, *args, **kwargs):
+            seen.append(quote.get("quantity"))
+            return original(quote, *args, **kwargs)
+
+        env.LOB.process_order = recording
+        try:
+            for _ in range(10):
+                actions = {
+                    f"agent_{i}": env.action_spaces[f"agent_{i}"].sample()
+                    for i in range(NUM_AGENTS)
+                }
+                _, _, terminateds, truncateds, _ = env.step(actions)
+                if terminateds.get("__all__") or truncateds.get("__all__"):
+                    break
+        finally:
+            env.LOB.process_order = original
+
+        assert seen, "no orders reached the book"
+        offenders = [q for q in seen
+                     if q is not None and not isinstance(q, int)]
+        assert not offenders, (
+            f"{len(offenders)} of {len(seen)} orders entered the book with a "
+            f"non-int size, e.g. {offenders[0]!r}"
+        )
+
+
+class TestArithmeticIsWellDefined:
+    """The mixes that must work, and the one that must not be reachable."""
+
+    def test_decimal_times_int_is_defined(self):
+        assert Decimal("10") * 3 == Decimal("30")
+
+    def test_decimal_times_float_raises(self):
+        """Documents *why* sizes are int: this is the error the orderbook has
+        two workarounds for, and it is a TypeError at runtime, not a warning."""
+        with pytest.raises(TypeError):
+            Decimal("10") * 3.0
+
+    def test_a_position_valuation_stays_decimal(self, stepped_env):
+        """int size x Decimal price must give Decimal money, every step."""
+        env, _ = stepped_env
+        for trader in env.traders:
+            value = trader.acc.net_position * trader.acc.VWAP
+            assert isinstance(value, Decimal)

--- a/gym_continuousDoubleAuction/train/callbk/league_based_self_play_callback.py
+++ b/gym_continuousDoubleAuction/train/callbk/league_based_self_play_callback.py
@@ -1,4 +1,5 @@
 from collections import defaultdict
+from decimal import Decimal
 
 import logging
 import numpy as np
@@ -285,7 +286,12 @@ class SelfPlayCallback(RLlibCallback):
             init_cash = env.init_cash
             num_agents = getattr(env, "num_of_agents", num_agents)
 
-        total_initial_cash = float(init_cash) * num_agents
+        # Decimal, not float, all the way through the check: the ledger is
+        # Decimal end to end and `info["NAV"]` is its exact `str()`, so parsing
+        # it back with Decimal makes the comparison exact. Going through float
+        # would reintroduce, at the last step, precisely the representation
+        # error the account type exists to avoid.
+        total_initial_cash = Decimal(str(init_cash)) * num_agents
 
         logger.debug(
             "episode %s parameters: env=%s env_runner=%s init_cash=%s "
@@ -296,24 +302,33 @@ class SelfPlayCallback(RLlibCallback):
 
         last_info = episode.get_infos(-1)
 
-        total_nav = 0.0
+        total_nav = Decimal(0)
         per_agent = []
         for i in range(num_agents):
             agent_key = f"agent_{i}"
             if agent_key in last_info:
-                nav = float(last_info[agent_key].get("NAV", "0"))
+                nav = Decimal(last_info[agent_key].get("NAV", "0"))
                 total_nav += nav
                 per_agent.append(f"  {agent_key} NAV: {nav:,.2f}")
 
         error = total_nav - total_initial_cash
-        conserved = abs(error) < self.nav_tolerance
+        # Inclusive: with the comparison exact, "within tolerance" includes the
+        # boundary, which is what makes nav_tolerance=0 mean "conservation must
+        # be exact" rather than "every episode is a violation". At the default
+        # 1e-6 the two forms differ only on an error of exactly 1e-6.
+        conserved = abs(error) <= self.nav_tolerance
 
         # The metric goes out whether or not the invariant held, so a run has a
         # series to look at rather than only the moment it broke. window=1
         # keeps it per-iteration rather than smoothed - an error that appears
         # in one episode out of many must not be averaged away.
         if metrics_logger:
-            metrics_logger.log_value("nav_conservation_error", abs(error), window=1)
+            # float() only at the boundary: the metrics stack reduces with
+            # NumPy and will not take a Decimal. The check above has already
+            # been decided exactly by this point.
+            metrics_logger.log_value(
+                "nav_conservation_error", float(abs(error)), window=1
+            )
 
         report = "\n".join(
             [f"Episode {episode.id_} NAV verification"]

--- a/gym_continuousDoubleAuction/train/train.py
+++ b/gym_continuousDoubleAuction/train/train.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import argparse
 import dataclasses
 import json
+import math
 import os
 import shutil
 from dataclasses import dataclass, field
@@ -46,6 +47,7 @@ from gym_continuousDoubleAuction.train.callbk.league_based_self_play_callback im
 from gym_continuousDoubleAuction.train.policy.policy_handler import (
     CHAMPION_PREFIX,
     create_multi_agent_config,
+    trainable_policy_ids,
 )
 
 logger = get_logger("gym_continuousDoubleAuction.train.train")
@@ -54,6 +56,22 @@ ENV_NAME = "continuousDoubleAuction-v0"
 
 #: The file every TrainConfig default is read from.
 TRAIN_CONFIG_FILE = "train_config.json"
+
+#: Per-iteration result dicts, one JSON object per line, under `log_base_dir`.
+#: `algo.train()` returns a full metrics dict every iteration and the loop used
+#: to read two keys out of it for a log line and drop the rest, so a finished
+#: run left behind checkpoints and no record of how it got there. This is the
+#: record. See doc/11 1.6.
+PROGRESS_FILE = "progress.jsonl"
+
+#: `result["learners"][<module_id>]["vf_explained_var"]`: the fraction of return
+#: variance the critic accounts for. Defined by RLlib as
+#: `ppo.LEARNER_RESULTS_VF_EXPLAINED_VAR_KEY` and written by PPOTorchLearner;
+#: spelled out here rather than imported so a rename in Ray degrades to a
+#: missing metric instead of an ImportError that stops training. A critic stuck
+#: near 0.0 is the failure this exists to make visible while a run is going,
+#: which no amount of reading `module_episode_returns_mean` will show.
+VF_EXPLAINED_VAR_KEY = "vf_explained_var"
 
 
 def _default(key: str):
@@ -244,6 +262,17 @@ class TrainConfig:
     def checkpoint_dir(self) -> str:
         """Root of the checkpoint tree. Individual saves are `iter_*` beneath it."""
         return os.path.abspath(os.path.join(self.log_base_dir, "chkpt"))
+
+    @property
+    def progress_path(self) -> str:
+        """The per-iteration JSONL log, beside the checkpoint tree.
+
+        Under `log_base_dir` rather than `episode_data_dir` deliberately: this
+        is one short line per iteration, so it belongs with the checkpoints that
+        must survive a disconnect, not with the per-episode pickles that
+        runtime_profiles.json keeps off the Drive FUSE layer.
+        """
+        return os.path.abspath(os.path.join(self.log_base_dir, PROGRESS_FILE))
 
     @property
     def env_config(self) -> dict:
@@ -903,6 +932,7 @@ def train(cfg: TrainConfig) -> Tuple[Algorithm, dict]:
         result = algo.train()
         iteration = int(result.get("training_iteration", iteration + 1))
         _log_iteration(iteration, target, result, cfg)
+        _append_progress(result, cfg)
 
         if cfg.chkpt_freq and iteration % cfg.chkpt_freq == 0:
             saved_at = iteration
@@ -918,15 +948,114 @@ def train(cfg: TrainConfig) -> Tuple[Algorithm, dict]:
     return algo, result
 
 
+def _json_safe(value):
+    """Recursively coerce a result dict into something `json.dump` accepts.
+
+    RLlib fills results with numpy scalars, numpy arrays, and the occasional
+    object with no JSON form at all. `default=` on json.dump would catch the
+    last of those, but it would also stringify every numpy float, turning a
+    column of numbers into a column of quoted numbers that whatever reads the
+    file has to parse back. Converting first keeps numbers as numbers and
+    reserves `str()` for the genuinely unserialisable.
+
+    Non-finite floats become null: NaN and Infinity are what Python's json emits
+    by default but are not valid JSON, and a NaN early in training - an
+    untrained critic's `vf_explained_var`, say - should not produce a file that
+    a strict parser rejects.
+    """
+    if isinstance(value, bool) or value is None or isinstance(value, (int, str)):
+        return value
+    if isinstance(value, float):
+        return value if math.isfinite(value) else None
+    if isinstance(value, dict):
+        return {str(k): _json_safe(v) for k, v in value.items()}
+    if isinstance(value, (list, tuple, set)):
+        return [_json_safe(v) for v in value]
+    # numpy scalars (.item()) before numpy arrays (.tolist()): a 0-d array has
+    # both, and .item() gives the scalar rather than a bare number in a list.
+    # A multi-element array has .item() too and raises on it, so a failed
+    # attempt has to fall through to the next rather than give up - that is the
+    # difference between logging [1, 2, 3] and logging the string "[1 2 3]".
+    for unwrap in ("item", "tolist"):
+        method = getattr(value, unwrap, None)
+        if callable(method):
+            try:
+                return _json_safe(method())
+            except Exception:
+                continue
+    return str(value)
+
+
+def _append_progress(result: dict, cfg: TrainConfig) -> None:
+    """Append one iteration's full result dict to `progress.jsonl`.
+
+    Opened, written, and closed per iteration rather than held open for the run:
+    a training run that is killed - a Colab disconnect, an OOM, a Ctrl-C - is
+    the normal way these runs end, and this way it keeps every iteration it had
+    finished instead of losing a buffer.
+
+    Every failure here is swallowed with a warning. Logging is instrumentation;
+    a full disk or a value that defeats `_json_safe` must never take down a run
+    that is otherwise training fine.
+    """
+    try:
+        os.makedirs(os.path.dirname(cfg.progress_path), exist_ok=True)
+        with open(cfg.progress_path, "a") as fh:
+            json.dump(_json_safe(result), fh)
+            fh.write("\n")
+            fh.flush()
+    except Exception:
+        logger.warning(
+            "could not append to %s - the run continues without a progress "
+            "record for this iteration", cfg.progress_path, exc_info=True,
+        )
+
+
+def vf_explained_var(result: dict, cfg: TrainConfig) -> dict:
+    """`vf_explained_var` per trainable module, as far as the result has it.
+
+    Only the modules in `policies_to_train` appear in the learner block, so the
+    frozen champions and the random baselines are absent by construction and
+    this is keyed on `trainable_policy_ids` rather than on every policy.
+
+    A module missing from the result is omitted rather than reported as 0.0:
+    absent and "the critic explains nothing" are different states, and this
+    metric exists precisely to tell them apart.
+    """
+    from ray.rllib.utils.metrics import LEARNER_RESULTS
+
+    learners = result.get(LEARNER_RESULTS) or {}
+    out = {}
+    for pid in trainable_policy_ids(cfg.num_trained_agents):
+        stats = learners.get(pid)
+        if isinstance(stats, dict) and VF_EXPLAINED_VAR_KEY in stats:
+            out[pid] = float(stats[VF_EXPLAINED_VAR_KEY])
+    return out
+
+
 def _log_iteration(i: int, total: int, result: dict, cfg: TrainConfig) -> None:
     from ray.rllib.utils.metrics import ENV_RUNNER_RESULTS
 
     env_runners = result.get(ENV_RUNNER_RESULTS, {})
     returns = env_runners.get("module_episode_returns_mean", {})
     steps = env_runners.get("num_env_steps_sampled", "n/a")
+    # vf_explained_var sits beside the returns because it is the one number that
+    # says whether the critic is learning at all. A run whose returns drift
+    # while every critic sits in the noise is a run whose advantages are noise,
+    # and that is worth seeing at iteration 3 rather than in a post mortem.
+    #
+    # Formatted to 3 significant figures rather than rounded to 3 decimals:
+    # this metric's whole diagnostic range is near zero, and `round(3.8e-05, 3)`
+    # prints `0.0` - which is how a critic that is merely dead ends up looking
+    # identical to one that reported nothing at all.
+    vf = ", ".join(
+        f"{pid}={value:.3g}" for pid, value in vf_explained_var(result, cfg).items()
+    )
     logger.info(
-        "iter %s/%s | env steps sampled: %s | module returns: %s",
+        "iter %s/%s | env steps sampled: %s | module returns: %s | "
+        "vf_explained_var: %s",
         i, total, steps, {k: round(float(v), 1) for k, v in returns.items()},
+        vf or "n/a",
     )
 
     # An iteration with no env_runners block sampled nothing the learner could


### PR DESCRIPTION
`config_tree` dropped the loader cache in its teardown while
$CDA_CONFIG_DIR still pointed at the modified copy, so the reload
repopulated the cache from the edited tree. monkeypatch restores the
variable, but not until after that teardown has already run.

Nothing noticed, because the one test that reaches past the loader into
module-level state - test_module_id_prefixes_come_from_the_file, which
reloads policy_handler - reloaded it inside its own finally, also with
the variable still set. POLICY_PREFIX therefore stayed at "agent_" for
the remainder of the session, and anything later that builds a ModuleID
looked up names no result would ever have.

The env var now goes back before the cache is dropped, in both places,
and the test asserts the prefix is actually restored.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01K2C8fZ7CPpwRjFk7oUcXvm