### PR TITLE
Give the log somewhere to live, and a date to live at

### DIFF
--- a/config/tunable_constants.json
+++ b/config/tunable_constants.json
@@ -43,11 +43,18 @@
 
   "logging": {
     "_source": "gym_continuousDoubleAuction/logging_setup.py",
-    "_note": "How the package configures the standard library logging module, applied once per process by the first get_logger call. level is the fallback: $CDA_LOG_LEVEL wins over it, which is how the level reaches Ray's worker processes - they are separate interpreters that never run train.main, so train.py exports the variable and each worker's first import picks it up. env_var is named here so the exporter and the reader agree on one string. The format carries the pid because with num_env_runners > 0 every worker logs into the same stream, and without it the episode hooks are unattributable.",
+    "_note": "How the package configures the standard library logging module, applied once per process by the first get_logger call. level is the fallback: $CDA_LOG_LEVEL wins over it, which is how the level reaches Ray's worker processes - they are separate interpreters that never run train.main, so train.py exports the variable and each worker's first import picks it up. env_var is named here so the exporter and the reader agree on one string. The format carries the pid because with num_env_runners > 0 every worker logs into the same stream, and without it the episode hooks are unattributable. It also carries iter=, the training iteration, so a log line can be joined to the progress.jsonl row for the same iteration; it reads '-' in any process that does not know the iteration, which is every env runner. datefmt carries the date because a training run outlasts a day and a time-only stamp cannot be ordered across midnight.",
     "level": "INFO",
     "env_var": "CDA_LOG_LEVEL",
-    "format": "%(asctime)s %(levelname)-7s pid=%(process)d %(name)s: %(message)s",
-    "datefmt": "%H:%M:%S"
+    "format": "%(asctime)s %(levelname)-7s pid=%(process)d iter=%(iteration)s %(name)s: %(message)s",
+    "datefmt": "%Y-%m-%d %H:%M:%S",
+
+    "_file_note": "The run log. Until this existed the package logged only to stdout, so the narrative a run is diagnosed from - the per-episode NAV tables, the league statistics, the ERROR that precedes a strict_nav_check raise - survived only in scrollback, while progress.jsonl kept the numbers. file_name is written under log_base_dir, beside progress.jsonl. Rotation bounds it: file_max_bytes per file, file_backup_count old files kept, so a long or resumed run cannot fill the disk. Set file_name to an empty string to disable file logging entirely.",
+    "_file_worker_note": "Every process writes its own file rather than sharing one, because RotatingFileHandler is not safe across processes - two of them crossing the size threshold together rename and truncate the same file underneath each other. The driver writes file_name; a worker writes the same name with its pid before the suffix (run.log -> run.4231.log). This matters rather than being a detail: the episode callbacks run on the env runners, so with num_env_runners > 0 the NAV tables and the conservation ERROR are emitted there and nowhere else. dir_env_var carries log_base_dir to those workers the same way env_var carries the level - they are separate interpreters that never run train.main.",
+    "dir_env_var": "CDA_LOG_DIR",
+    "file_name": "run.log",
+    "file_max_bytes": 10485760,
+    "file_backup_count": 5
   },
 
   "visualize_paths": {

--- a/doc/08_self_play_league.md
+++ b/doc/08_self_play_league.md
@@ -321,9 +321,15 @@ Episode 12345 Started - Policy Map:
 | `league_mean_return` | Mean module return across the league | 10 |
 | `league_std_return` | Std dev of module returns | 10 |
 | `nav_conservation_error` | `abs(total NAV − total initial cash)`; per *episode*, not per iteration | 1 |
+| `pass_action_fraction` | Share of agent-steps that chose to do nothing; per *episode* | 10 |
+| `order_rejection_fraction` | Share of agent-steps whose order was refused for want of cash; per *episode* | 10 |
 
-**Four metrics is the entirety of what reaches RLlib's structured logger.** Still absent: NAV
+**Six metrics is the entirety of what reaches RLlib's structured logger.** Still absent: NAV
 distribution, drawdown, trade counts, maker/taker ratio, champion promotions.
+
+`pass_action_fraction` is the one to watch against this document's own warning: a league whose
+policies collapse to always-pass still clears the promotion threshold, because 0 beats a negative
+mean. Returns will not show it; this will.
 
 `vf_explained_var` is no longer among them, but it is not lost either: it is in the per-iteration
 log line and, with every other value RLlib computes, in `progress.jsonl`. That is the general

--- a/doc/08_self_play_league.md
+++ b/doc/08_self_play_league.md
@@ -320,11 +320,15 @@ Episode 12345 Started - Policy Map:
 | `league_size` | `num_trainable + num_random + champion_count` | 1 |
 | `league_mean_return` | Mean module return across the league | 10 |
 | `league_std_return` | Std dev of module returns | 10 |
+| `nav_conservation_error` | `abs(total NAV − total initial cash)`; per *episode*, not per iteration | 1 |
 
-**Three metrics is the entirety of what reaches RLlib's structured logger.** Everything else —
-NAV distribution, drawdown, trade counts, maker/taker ratio, champion promotions,
-`vf_explained_var` — is printed to stdout and lost. See
-[11_logging_and_observability.md](11_logging_and_observability.md).
+**Four metrics is the entirety of what reaches RLlib's structured logger.** Still absent: NAV
+distribution, drawdown, trade counts, maker/taker ratio, champion promotions.
+
+`vf_explained_var` is no longer among them, but it is not lost either: it is in the per-iteration
+log line and, with every other value RLlib computes, in `progress.jsonl`. That is the general
+shape now — the gap is aggregation into a metric worth alerting on, not capture. See
+[11_logging_and_observability.md](11_logging_and_observability.md) §1.6 and §2.1.
 
 Watch `league_size` and `league_mean_return` together: adding champions should raise difficulty
 and depress mean return before agents adapt.

--- a/doc/10_testing.md
+++ b/doc/10_testing.md
@@ -17,7 +17,7 @@ of `self.assertX(...)`, and pytest's built-in xunit-style hooks (`setup_method` 
 `unittest`-based suite; see [17_changelog.md](17_changelog.md).
 
 ```bash
-# everything (333 tests: 307 unit + 26 integration)
+# everything (349 tests: 323 unit + 26 integration)
 python -m pytest gym_continuousDoubleAuction/test -q
 
 # unit tests only, skipping the slow RLlib ones
@@ -46,7 +46,7 @@ collects `TestCase` subclasses, and none of these classes are one any more. **[v
 `python -m unittest discover -s gym_continuousDoubleAuction/test -p "test_*.py"` reports
 `Ran 0 tests`.
 
-**[verified]** — `332 passed, 1 xfailed` (the xfail pins S1-1; see §6.2.2).
+**[verified]** — `348 passed, 1 xfailed` (the xfail pins S1-1; see §6.2.2).
 
 ### File inventory
 
@@ -75,9 +75,10 @@ Counts re-measured with `--collect-only`; the earlier `90` predated the config a
 | `test_checkpointing.py` | 50 | Checkpoint retention, restore selection, league state across a save |
 | `test_champion_trigger.py` | 6 | League statistics with modules that played no episodes |
 | `test_progress_log.py` | 19 | `progress.jsonl` writer, numpy/NaN handling, `vf_explained_var` extraction |
-| `test_info_dict.py` | 18 | Per-step `info`: back-compat, reward terms summing exactly, live counters, spread, JSON |
+| `test_info_dict.py` | 22 | Per-step `info`: back-compat, reward terms summing exactly, live counters, spread, pass/rejection fields, JSON |
 | `test_type_policy.py` | 15 | Decimal money/prices, int sizes, no field changing type mid-episode, book boundary |
-| **unit total** | **307** | |
+| `test_activity_metrics.py` | 12 | `pass_action_fraction` / `order_rejection_fraction`: the S1-3 detector, per-episode tallies, pickling |
+| **unit total** | **323** | |
 | `integration/test_league_wiring.py` | 13 | RLlib wiring, 3 topologies |
 | `integration/test_checkpoint_roundtrip.py` | 7 | One real save and restore: weights, league, iteration, optimizer |
 | `integration/test_progress_and_vf.py` | 6 | A real short run's `progress.jsonl`; `vf_explained_var` reported and finite (1 xfail pins S1-1) |

--- a/doc/10_testing.md
+++ b/doc/10_testing.md
@@ -17,7 +17,7 @@ of `self.assertX(...)`, and pytest's built-in xunit-style hooks (`setup_method` 
 `unittest`-based suite; see [17_changelog.md](17_changelog.md).
 
 ```bash
-# everything (314 tests: 288 unit + 26 integration)
+# everything (333 tests: 307 unit + 26 integration)
 python -m pytest gym_continuousDoubleAuction/test -q
 
 # unit tests only, skipping the slow RLlib ones
@@ -46,7 +46,7 @@ collects `TestCase` subclasses, and none of these classes are one any more. **[v
 `python -m unittest discover -s gym_continuousDoubleAuction/test -p "test_*.py"` reports
 `Ran 0 tests`.
 
-**[verified]** — `313 passed, 1 xfailed` (the xfail pins S1-1; see §6.2.2).
+**[verified]** — `332 passed, 1 xfailed` (the xfail pins S1-1; see §6.2.2).
 
 ### File inventory
 
@@ -66,7 +66,7 @@ Counts re-measured with `--collect-only`; the earlier `90` predated the config a
 | `test_obs_market_features.py` | 17 | `log_mid`, `log1p_spread_ticks` |
 | `test_reward_logic.py` | 4 | Reward formula components |
 | `test_nav_callback.py` | 8 | Episode-end NAV conservation check: raises, tolerance, metric, strict off, exactness at a scale `float` cannot resolve |
-| `test_logging_setup.py` | 10 | Level resolution and export, handler setup, no `print` in `envs/` or `train/` |
+| `test_logging_setup.py` | 29 | Level resolution and export, handler setup, no `print` in `envs/` or `train/`, the rotating run log, per-worker files, the `iter=` tag, dated stamps |
 | `test_probabilistic_mapping.py` | 1 | League matchmaking distribution |
 | `test_config_loading.py` | 15 | `train_config.json` → `TrainConfig` → env |
 | `test_config_sources.py` | 26 | No literal copy of a configured value survives in Python |
@@ -77,7 +77,7 @@ Counts re-measured with `--collect-only`; the earlier `90` predated the config a
 | `test_progress_log.py` | 19 | `progress.jsonl` writer, numpy/NaN handling, `vf_explained_var` extraction |
 | `test_info_dict.py` | 18 | Per-step `info`: back-compat, reward terms summing exactly, live counters, spread, JSON |
 | `test_type_policy.py` | 15 | Decimal money/prices, int sizes, no field changing type mid-episode, book boundary |
-| **unit total** | **288** | |
+| **unit total** | **307** | |
 | `integration/test_league_wiring.py` | 13 | RLlib wiring, 3 topologies |
 | `integration/test_checkpoint_roundtrip.py` | 7 | One real save and restore: weights, league, iteration, optimizer |
 | `integration/test_progress_and_vf.py` | 6 | A real short run's `progress.jsonl`; `vf_explained_var` reported and finite (1 xfail pins S1-1) |

--- a/doc/11_logging_and_observability.md
+++ b/doc/11_logging_and_observability.md
@@ -57,7 +57,7 @@ Two further notes:
 **Three metrics** is the entirety of what reaches RLlib's structured logger, alongside RLlib's
 own built-ins.
 
-### 1.3 Logging (stdout, filterable)
+### 1.3 Logging (stdout and a run log, filterable)
 
 Every module reports through the standard library's `logging`, configured in one place by
 [`logging_setup.py`](../gym_continuousDoubleAuction/logging_setup.py):
@@ -79,7 +79,7 @@ whose stdout *is* the product - as are the demo scripts under `envs/orderbook/te
 | `WARNING` | A recoverable surprise: a requested GPU that is absent, an unreadable checkpoint, a repaired league state |
 | `ERROR` | A broken invariant: NAV conservation failing, a champion that could not be created |
 
-Two properties this buys that `print` could not:
+Three properties this buys that `print` could not:
 
 * **Worker attribution.** The format carries the pid, so with `num_env_runners > 0` the
   interleaved episode hooks are separable by process. Previously eight workers wrote
@@ -88,6 +88,14 @@ Two properties this buys that `print` could not:
   `--log-level` on the random runner) sets the level. Remote EnvRunners are separate interpreters
   that never run `main()`, so `configure()` exports the level into the environment and each
   worker's first `get_logger` call picks it up.
+* **A record that outlives the terminal.** See §1.9 - the log is written to a rotating file under
+  `log_base_dir` as well as stdout.
+
+Each line is stamped `<date> <time> <level> pid=<pid> iter=<iteration> <module>: <message>`. The
+date is there because a training run outlasts a day and a time-only stamp cannot be ordered across
+midnight; `iter=` is the training iteration, which is what lets a line be joined to the
+`progress.jsonl` row for the same iteration. It reads `-` in any process that does not know the
+iteration - see §1.9.
 
 `cda_log_level` is deliberately separate from `log_level`, which is Ray's: Ray at INFO is noise,
 while this package at INFO is the output a run is meant to produce.
@@ -280,6 +288,55 @@ mutation restoring that `* 1.0` left every other test in the file green.
 and prices are emitted as `float` there, except `NAV`, which pays the string cost because the
 conservation check (§1.5) depends on its exactness. Sizes need no conversion — `int` is JSON-native.
 
+### 1.9 The run log
+
+§1.6 gave the run a machine-readable history and §1.7 gave the step one, but the log itself was
+still written only to stdout. So a finished run left its *numbers* on disk and its *narrative* in
+scrollback — the per-episode NAV tables, the league statistics, and the ERROR that immediately
+precedes a `strict_nav_check` raise. [17 §17](17_changelog.md) records two GPU runs diagnosed
+exactly that way, after the fact, from a terminal buffer.
+
+Every process now writes a rotating log file under `log_base_dir`, beside `progress.jsonl`:
+
+| File | Written by | Contains |
+|---|---|---|
+| `run.log` | the driver | iteration summaries, league statistics, champion events, checkpoint writes |
+| `run.<pid>.log` | each env runner | the per-episode NAV tables and the conservation ERROR |
+
+**Why one file per process rather than one shared file.** `RotatingFileHandler` is not safe across
+processes: two of them crossing the size threshold together rename and truncate the same file
+underneath each other, losing lines from both. That rules out sharing — and sharing is not
+something to give up lightly here, because the split is not cosmetic. The episode callbacks run on
+the env runners, so with `num_env_runners > 0` the NAV tables and the conservation ERROR are
+emitted in a worker and *nowhere else*. **[verified]** against a real two-runner run: a
+driver-only file captured 7 lines and none of the NAV tables; with per-process files the worker
+logs carry them. `log_base_dir` reaches the workers through `$CDA_LOG_DIR`, the same channel the
+level takes, because an env runner never executes `train.main`.
+
+Rotation bounds the output: `file_max_bytes` per file, `file_backup_count` older files kept. This
+is the one item from §3's persistence table that the run log could otherwise have re-created.
+Setting `file_name` to `""` disables file logging entirely.
+
+A failure to open the file is a **warning, not an exception**. Logging is instrumentation, and a
+run that cannot write its log should still train — the same rule `_append_progress` follows.
+
+**The `iter=` field.** `progress.jsonl` is keyed by iteration and the log was keyed by nothing, so
+joining them meant matching on wall-clock order. Log lines now carry the training iteration,
+tracked in a `ContextVar` — per-thread rather than a module global, since the driver loop may not
+be the only thread. It reads `-` where the iteration is unknown, which is every env runner and the
+driver before the first iteration and after the last. Not `0`, which is a real iteration number.
+
+So with remote runners a worker's NAV table is dated, attributed to its pid and durable, but reads
+`iter=-`: the worker genuinely does not know which iteration its episode belongs to. Recovering
+that association means passing the iteration to the runners, which is a change to what RLlib hands
+the callbacks rather than a logging change.
+
+Covered by `test_logging_setup.py` (29 tests): the file appears beside the metrics and mirrors
+stdout, rotation bounds it, an unwritable destination warns instead of raising, a worker resolves
+the directory from the environment and writes its own pid-suffixed file, the driver keeps the
+plain name, the iteration tag follows `set_iteration` and defaults to a dash, and the timestamp
+carries the date.
+
 ---
 
 ## 2. What is not logged but should be
@@ -374,9 +431,12 @@ chosen for, and it makes the info dict awkward for RLlib metric aggregation.
 | `pickle` format | Arbitrary code execution on load; prefer `npz` / `parquet` / `jsonl` |
 | `progress.jsonl` grows without rotation | One line per iteration is small, but nothing bounds it across a long series of resumed runs |
 
-Two things are no longer in this table. Logging itself: output is levelled, attributable and
-switchable, and the `g_store` dead code is gone (§1.3, §1.4). And the absence of a per-iteration
-training history: `progress.jsonl` is that machine-readable record (§1.6).
+Three things are no longer in this table. Logging itself: output is levelled, attributable,
+switchable and now durable, written to a rotating file per process as well as stdout (§1.3, §1.9),
+and the `g_store` dead code is gone (§1.4). The absence of a per-iteration training history:
+`progress.jsonl` is that machine-readable record (§1.6). And the run log does not re-create the
+unbounded-growth problem it would otherwise have added — `file_max_bytes` and `file_backup_count`
+bound it.
 
 ---
 

--- a/doc/11_logging_and_observability.md
+++ b/doc/11_logging_and_observability.md
@@ -44,18 +44,22 @@ Two further notes:
   from an older version of `test_nav_callback.py`, not fixtures anything reads, and the suite no
   longer regenerates them.
 
-### 1.2 RLlib `metrics_logger` custom metrics (per training iteration)
+### 1.2 RLlib `metrics_logger` custom metrics
 
-**Where:** `on_train_result`.
+| Metric | Value | Window | Emitted in |
+|---|---|---|---|
+| `nav_conservation_error` | `abs(total NAV − total initial cash)`, as a float | 1 | `on_episode_end` |
+| `league_size` | `num_trainable + num_random + champion_count` | 1 | `on_train_result` |
+| `league_mean_return` | Mean module return across the league | 10 | `on_train_result` |
+| `league_std_return` | Std dev of module returns | 10 | `on_train_result` |
 
-| Metric | Value | Window |
-|---|---|---|
-| `league_size` | `num_trainable + num_random + champion_count` | 1 |
-| `league_mean_return` | Mean module return across the league | 10 |
-| `league_std_return` | Std dev of module returns | 10 |
-
-**Three metrics** is the entirety of what reaches RLlib's structured logger, alongside RLlib's
+**Four metrics** is the entirety of what reaches RLlib's structured logger, alongside RLlib's
 own built-ins.
+
+Three are per *iteration*, from `on_train_result`. `nav_conservation_error` is per *episode*, from
+`on_episode_end`, which is why its window is 1: an error in one episode out of many must not be
+averaged away (§1.5). It is also the only one of the four emitted on the env runners rather than
+the driver.
 
 ### 1.3 Logging (stdout and a run log, filterable)
 

--- a/doc/11_logging_and_observability.md
+++ b/doc/11_logging_and_observability.md
@@ -49,17 +49,33 @@ Two further notes:
 | Metric | Value | Window | Emitted in |
 |---|---|---|---|
 | `nav_conservation_error` | `abs(total NAV − total initial cash)`, as a float | 1 | `on_episode_end` |
+| `pass_action_fraction` | Share of agent-steps where the agent chose `category=0` | 10 | `on_episode_end` |
+| `order_rejection_fraction` | Share of agent-steps where an order was refused for want of cash | 10 | `on_episode_end` |
 | `league_size` | `num_trainable + num_random + champion_count` | 1 | `on_train_result` |
 | `league_mean_return` | Mean module return across the league | 10 | `on_train_result` |
 | `league_std_return` | Std dev of module returns | 10 | `on_train_result` |
 
-**Four metrics** is the entirety of what reaches RLlib's structured logger, alongside RLlib's
+**Six metrics** is the entirety of what reaches RLlib's structured logger, alongside RLlib's
 own built-ins.
 
-Three are per *iteration*, from `on_train_result`. `nav_conservation_error` is per *episode*, from
-`on_episode_end`, which is why its window is 1: an error in one episode out of many must not be
-averaged away (§1.5). It is also the only one of the four emitted on the env runners rather than
-the driver.
+The split matters. The three `on_train_result` metrics are per *iteration* and are emitted on the
+driver. The three `on_episode_end` ones are per *episode* and are emitted **on the env runners**,
+which is where the episode hooks run. `nav_conservation_error` keeps `window=1` because an error in
+one episode out of many must not be averaged away (§1.5); the two activity fractions use
+`window=10`, matching the league metrics, because a single episode's fraction is noisy and the
+question they answer is the trend.
+
+**Why the two activity fractions exist.** They separate the two behaviours a return series cannot
+tell apart. An agent that stops trading looks identical in its returns whether it *chose* to pass
+or whether every order it sent was refused. The first is S1-3: `entropy_coeff` is 0.0, policies can
+collapse to always-pass, and such a policy still clears the champion promotion threshold because 0
+beats a negative league mean — so the pool fills with do-nothing snapshots while the returns series
+looks unremarkable. `pass_action_fraction` trending to 1.0 states it outright. The second is a
+policy quoting past its cash; `order_step_placed` cannot express it, being 0 both for an agent that
+never tried and for one whose order was refused.
+
+**[verified]** on a real 2-iteration run: `pass_action_fraction` reported `0.122` and `0.130`,
+consistent with 1 of 9 action categories being the pass code for near-uniform untrained policies.
 
 ### 1.3 Logging (stdout and a run log, filterable)
 
@@ -211,7 +227,8 @@ is not settled here.
 
 | Group | Fields |
 |---|---|
-| Account (§2.3) | `net_position`, `VWAP`, `cash`, `cash_on_hold`, `position_val`, `drawdown`, `max_nav`, `num_trades_step`, `num_passive_fills_step`, `order_step_placed` |
+| Account (§2.3) | `net_position`, `VWAP`, `cash`, `cash_on_hold`, `position_val`, `drawdown`, `max_nav`, `num_trades_step`, `num_passive_fills_step`, `order_step_placed`, `num_rejected_step` |
+| Activity (§2.2) | `is_pass_action` — did this agent choose to do nothing this step |
 | Market (§2.2) | `last_price`, `best_bid`, `best_ask`, `spread` |
 | Reward (§2.4) | `reward_terms`: `nav_term`, `order_penalty`, `trade_penalty`, `drawdown_penalty`, `passive_bonus` |
 | Action | `model_action` — as the model emitted it, before `set_actions` reshapes it for the book |
@@ -376,12 +393,16 @@ or aggregated into a metric worth alerting on.
 `last_price` and the bid-ask spread are **done** — both are in the per-step `info` dict (§1.7),
 alongside `best_bid` and `best_ask`. What is still missing:
 
+The do-nothing count and the rejection rate are **done**, and are metrics rather than only
+fields: `is_pass_action` and `num_rejected_step` per agent-step in `info`, aggregated into
+`pass_action_fraction` and `order_rejection_fraction` (§1.2). The pass flag is set where
+`_CATEGORY_MAP` lives, so a reader of `info` does not need to know that `category=0` means pass;
+`test_info_dict.py` cross-checks the two agree.
+
 | Missing | Why it matters |
 |---|---|
 | Order book depth per level | Liquidity analysis |
-| Market / limit / modify / cancel action counts per episode | Reveals strategy evolution |
-| Count of `category=0` (do-nothing) actions | **Directly detects the passivity collapse predicted by S1-3** |
-| Order rejection / no-op rate | Signals cash constraints or blind modify/cancel actions ([04](04_accounting.md) §3) |
+| Market / limit / modify / cancel action counts per episode | Reveals strategy evolution — the *pass* share is now covered, the breakdown across the other four types is not |
 
 ### 2.3 Agent and account state
 
@@ -459,15 +480,26 @@ metrics_logger.log_value("pass_action_fraction", n_pass / n_actions, window=10)
 metrics_logger.log_value("vf_explained_var", ...,  window=1)
 ```
 
-Highest-value additions, in order:
+Item 3 is **done** — `pass_action_fraction` and `order_rejection_fraction` are metrics (§1.2).
 
-1. **Log reward sub-components** into `metrics_logger` from `on_episode_step` / `on_episode_end`.
-2. **Log per-agent final account state** — NAV, position, drawdown, VWAP — at episode end.
-3. **Log the do-nothing action fraction and the order rejection rate**, so passivity collapse and
-   blind modify/cancel actions become measurable.
-4. **Export market price and spread** into the info dict — already in env state, just not
-   surfaced.
+Items 1, 2 and 4 are **half done, and the half that is missing is the same one in each case**: the
+reward sub-components, the per-agent account state, and the market price and spread are all
+captured per step in `info` (§1.7), but none is reduced into a `metrics_logger` value. The data
+exists; nothing aggregates it. That is the shape of what is left across this whole document —
+capture is now good, aggregation is four league-and-NAV metrics plus the two above.
+
+What remains, in order:
+
+1. **Reduce the reward sub-components into metrics** from `on_episode_end`, so the variance split
+   [07](07_reward_function.md) §6.4 prescribes is watchable during a run rather than computed
+   afterwards from `progress.jsonl`.
+2. **Reduce per-agent end-of-episode account state** — NAV, position, drawdown, VWAP — the same
+   way.
+3. **Surface the §2.1 training metrics** (`vf_loss` vs unclipped, KL, clip fraction, per-policy
+   reward spread, throughput) in the iteration log line. All are already in `progress.jsonl`.
+4. **League state** (§2.5): champion promotion as a metric rather than a log line, per-champion
+   win rate, time since last snapshot — the last of these is already computed in
+   `_should_create_champion` and discarded.
 5. **Per-episode desk metrics** (Sharpe, max drawdown, turnover, maker ratio, inventory) through
-   `metrics_logger`, so they land in TensorBoard alongside returns. The `on_episode_end` hook
-   already has everything it needs. See
+   `metrics_logger`. The `on_episode_end` hook already has everything it needs. See
    [13_perspective_financial_trader.md](13_perspective_financial_trader.md) §7.

--- a/doc/14_perspective_ai_engineer.md
+++ b/doc/14_perspective_ai_engineer.md
@@ -125,6 +125,14 @@ Three of these are trivially removable:
 This is the weakest engineering area. Full audit in
 [11_logging_and_observability.md](11_logging_and_observability.md); the summary:
 
+> **This section is the original audit, kept as the record of what was found.** Most of it has
+> since been addressed — there is a logging framework, no `print()` survives in `envs/` or
+> `train/`, output is levelled and worker-attributed and written to a rotating run log, the
+> conservation check raises and emits a metric, and `vf_explained_var` is surfaced per iteration.
+> The custom-metric count is four rather than three. Read
+> [11](11_logging_and_observability.md) §1 for the current state; the bullets below describe the
+> starting point, not today.
+
 - **No logging framework at all.** **[verified]** zero `import logging` in the repository.
 - **~86 `print()` calls** in `envs/` + `train/`, 42 of them in `SelfPlayCallback` — including a
   3+-line banner per episode start listing the full policy map, five `DEBUG:`-prefixed lines and

--- a/doc/17_changelog.md
+++ b/doc/17_changelog.md
@@ -748,3 +748,53 @@ while `last_price` is a separate anchor consumed only by `_set_price`'s NumPy ar
 `info` is unaffected as a format, being a serialisation boundary where JSON has no `Decimal` —
 except that `net_position` is now a plain `int` rather than a `float()` cast that existed only to
 hide the account changing type underneath it.
+
+---
+
+## 21. The log outlives the terminal
+
+§18 gave the run a machine-readable history and §19 gave the step one. The log itself was still
+written only to stdout, so a finished run left its numbers on disk and its narrative in scrollback:
+the per-episode NAV tables, the league statistics, and the ERROR that immediately precedes a
+`strict_nav_check` raise. §17 records two GPU runs diagnosed exactly that way — after the fact,
+from a terminal buffer. There was one `addHandler` call in the package and it attached a
+`StreamHandler`.
+
+**Every process now writes a rotating log file under `log_base_dir`, beside `progress.jsonl`** —
+`run.log` from the driver, `run.<pid>.log` from each env runner. Bounded by `file_max_bytes` and
+`file_backup_count`, so it does not re-create the unbounded-growth problem [11 §3] lists for the
+episode pickles. A failure to open it warns rather than raising: instrumentation must not take
+down a run that is otherwise training, the same rule `_append_progress` follows.
+
+**One file per process is not a detail, and measuring it changed the design.** The first version
+wrote from the driver only, on the reasoning that `RotatingFileHandler` is unsafe across processes
+— two of them crossing the size threshold together rename and truncate the same file — and that
+Ray captures worker stdout anyway. A real two-runner run showed what that costs: the driver file
+held 7 lines and **not one NAV table**. The episode callbacks run on the env runners, so with
+`num_env_runners > 0` the NAV tables and the conservation ERROR are emitted in a worker and reach
+no file at all. Since the shipped runtime profiles use `num_env_runners=2`, driver-only logging
+would have missed precisely the lines that motivated the change. Per-process files keep them and
+sidestep the rotation race, since no two processes share an inode. `log_base_dir` reaches the
+workers through `$CDA_LOG_DIR`, the same channel the level already takes.
+
+**Timestamps carry the date.** `datefmt` was `"%H:%M:%S"`. A training run outlasts a day, so a
+time-only stamp cannot be ordered across midnight or joined to anything dated.
+
+**Log lines carry the training iteration.** `progress.jsonl` is keyed by iteration and the log was
+keyed by nothing, so relating the two meant matching on wall-clock order. Lines are now stamped
+`iter=<n>`, tracked in a `ContextVar` — per-thread, not a module global, since the driver loop may
+not be the only thread — and injected by a filter on the *handlers* rather than the logger, because
+a filter on the package logger never sees records propagating up from a child module. It reads `-`
+where the iteration is unknown, which is deliberate: `0` is a real iteration number.
+
+Being honest about the limit: with remote runners a worker's NAV table is dated, attributed and
+durable but reads `iter=-`. The worker does not know which iteration its episode belongs to.
+Recovering that means passing the iteration to the runners, which is a change to what RLlib hands
+the callbacks rather than a logging change.
+
+`test_logging_setup.py` grows from 10 tests to 29. Two isolation hazards the new ones introduced
+are handled in the fixture rather than left to luck: file handles are closed before pytest removes
+the `tmp_path` they point into, and `$CDA_LOG_DIR` is restored, since `configure` now exports it
+and a leaked value would make the next test write into a directory that no longer exists.
+
+See [11 §1.9](11_logging_and_observability.md).

--- a/doc/17_changelog.md
+++ b/doc/17_changelog.md
@@ -798,3 +798,54 @@ the `tmp_path` they point into, and `$CDA_LOG_DIR` is restored, since `configure
 and a leaked value would make the next test write into a directory that no longer exists.
 
 See [11 §1.9](11_logging_and_observability.md).
+
+---
+
+## 22. Two behaviours a return series cannot tell apart
+
+An agent that stops trading looks the same in its returns whether it *chose* to pass or whether
+every order it sent was refused for want of cash. Both produce a flat, unremarkable line, and
+nothing recorded could separate them.
+
+The first case is **S1-1's companion, S1-3**. `entropy_coeff` is 0.0, so policies can collapse to
+always-pass, and a do-nothing policy still clears the champion promotion threshold because 0 beats
+a negative league mean. The pool then fills with snapshots of the do-nothing policy while the
+returns series looks ordinary. [11 §2.2](11_logging_and_observability.md) has listed the
+`category=0` count as "**directly detects** the passivity collapse predicted by S1-3" since the
+audit; it was still not counted.
+
+The second is a policy quoting past its cash. `order_step_placed` cannot express it: that flag is
+`0` both for an agent that never tried and for one whose order was refused, which are opposite
+behaviours.
+
+**Both are now metrics** — `pass_action_fraction` and `order_rejection_fraction`, per episode,
+`window=10` (§1.2). The custom-metric count goes from four to six.
+
+Two details worth recording.
+
+**The pass flag is set where the encoding lives.** `is_pass_action` is written in `set_actions`,
+beside `_CATEGORY_MAP`, rather than derived by a consumer from `category == 0` — a reader of `info`
+should not have to know the action encoding to ask whether an agent passed. `test_info_dict.py`
+cross-checks that the flag and the encoding agree, over every agent-step of a real episode; they
+did, 200 of 200.
+
+**A counter that never fires is indistinguishable from a broken one.** The first run of the
+rejection counter reported 0 across 200 agent-steps, which proves nothing — at `init_cash=1e6`
+every order is affordable. Re-run at `init_cash=500` it reported 151 of 200, and that case is now
+a test, so the counter is known to be able to fire rather than assumed to be.
+
+The tally is a plain dict keyed by episode ID, not a `defaultdict` with a lambda factory: this
+callback is cloudpickled into every checkpoint, and a lambda default_factory is exactly the kind of
+thing that passes every local test and fails on a restore path nobody exercised. There is a test
+that pickles the callback mid-episode. It is also counted independently of the per-episode pickle
+store, since `episode_data_dir=None` is a supported configuration and these metrics must not
+depend on that dump being switched on.
+
+**[verified]** on a real 2-iteration run: `pass_action_fraction` reported `0.122` and `0.130`,
+consistent with 1 of 9 action categories being the pass code for near-uniform untrained policies.
+
+This also makes [11 §4](11_logging_and_observability.md)'s recommendation list accurate again.
+Item 3 is done; items 1, 2 and 4 turn out to be half done in the same way — the reward
+sub-components, the per-agent account state and the market price and spread are all captured in
+`info` but none is reduced into a metric. That is the shape of what remains: capture is good,
+aggregation is six metrics.

--- a/gym_continuousDoubleAuction/envs/account/account.py
+++ b/gym_continuousDoubleAuction/envs/account/account.py
@@ -36,6 +36,11 @@ class Account(Calculate, Cash_Processor):
         self.num_trades_step = 0 # trades in current environment step
         self.num_passive_fills_step = 0 # passive executions in current step
         self.order_step_placed = 0 # 1 if a Market/Limit order was placed this step
+        # Orders refused by _order_approved this step. order_step_placed cannot
+        # stand in for this: it is 0 both for an agent that never tried and for
+        # one whose order was refused, and those are opposite behaviours - the
+        # second is an agent repeatedly quoting past its cash (doc/11 2.2).
+        self.num_rejected_step = 0
 
         # Written by Reward_Helper.set_reward each step, read by Info_Helper.
         # The reward used to be a single number with its five components
@@ -70,6 +75,7 @@ class Account(Calculate, Cash_Processor):
         self.num_trades_step = 0
         self.num_passive_fills_step = 0
         self.order_step_placed = 0
+        self.num_rejected_step = 0
 
         # See __init__ for what these are and why they exist.
         self.drawdown = 0.0

--- a/gym_continuousDoubleAuction/envs/agent/trader.py
+++ b/gym_continuousDoubleAuction/envs/agent/trader.py
@@ -95,9 +95,14 @@ class Trader(Random_agent):
 
         else: # not enough cash to place order
             #print('Invalid order: order value > cash available.', self.ID)
-            
+
             # print("\nOrder NOT approved: -ve NAV for trader_ID {}.\n".format(self.ID))
 
+            # A refusal used to leave no trace at all: the agent asked to trade
+            # and the book never heard about it. Counted so the rejection rate
+            # is measurable - a policy quoting past its cash every step looks
+            # identical to a passive one from returns alone (doc/11 2.2).
+            self.acc.num_rejected_step += 1
             return trades, order_in_book
 
     def _order_approved(self, side, size, price, LOB):

--- a/gym_continuousDoubleAuction/envs/exchg/action_helper.py
+++ b/gym_continuousDoubleAuction/envs/exchg/action_helper.py
@@ -155,10 +155,20 @@ class Action_Helper():
         """
 
         acts = []
+        # Which agents chose to do nothing this step. Recorded here rather than
+        # derived by a consumer from `category == 0`, because _CATEGORY_MAP is
+        # what defines that and it lives in this module: a reader of `info`
+        # should not have to know the action encoding to ask "did this agent
+        # pass?". This is the S1-3 detector - a league whose policies collapse
+        # to always-pass still clears the promotion threshold, since 0 beats a
+        # negative mean, so the collapse is invisible from returns (doc/11 2.2).
+        self.pass_agents = set()
         for key, value in model_outs.items():
             act = self._set_action_mkt_depth(key, value)
             if act.get("side") is not None:
                 acts.append(act)
+            else:
+                self.pass_agents.add(key)
 
         return acts
 

--- a/gym_continuousDoubleAuction/envs/exchg/exchg_helper.py
+++ b/gym_continuousDoubleAuction/envs/exchg/exchg_helper.py
@@ -117,6 +117,7 @@ class Exchg_Helper(State_Helper, Action_Helper, Reward_Helper, Done_Helper, Info
             trader.acc.num_trades_step = 0
             trader.acc.num_passive_fills_step = 0
             trader.acc.order_step_placed = 0
+            trader.acc.num_rejected_step = 0
 
         dones, truncateds = self.set_all_done(dones)
 

--- a/gym_continuousDoubleAuction/envs/exchg/info_helper.py
+++ b/gym_continuousDoubleAuction/envs/exchg/info_helper.py
@@ -71,7 +71,13 @@ class Info_Helper(object):
             "num_trades_step": acc.num_trades_step,
             "num_passive_fills_step": acc.num_passive_fills_step,
             "order_step_placed": acc.order_step_placed,
+            "num_rejected_step": acc.num_rejected_step,
         })
+
+        # Did this agent choose to do nothing this step? The two behaviours a
+        # return series cannot tell apart: passing, and quoting past your cash
+        # so that every order is refused.
+        info["is_pass_action"] = agent_key in getattr(self, "pass_agents", set())
 
         # Reward decomposition (doc/11 2.4). The five signed contributions that
         # sum to `reward`, so the variance split in doc/07 6.4 is measurable

--- a/gym_continuousDoubleAuction/logging_setup.py
+++ b/gym_continuousDoubleAuction/logging_setup.py
@@ -41,7 +41,9 @@ Levels used across the package:
 """
 from __future__ import annotations
 
+import contextvars
 import logging
+import logging.handlers
 import os
 from typing import Optional
 
@@ -52,6 +54,60 @@ from gym_continuousDoubleAuction.config_loader import constants
 ROOT_NAME = "gym_continuousDoubleAuction"
 
 _configured = False
+_log_file_path: Optional[str] = None
+
+#: The training iteration in progress, for the `iter=` field of every log line.
+#: A ContextVar rather than a global so it is per-thread: RLlib may run the
+#: driver loop alongside other threads, and an int here would be shared by all
+#: of them. Unset in any process that does not know the iteration - every env
+#: runner - where it formats as "-".
+_iteration: contextvars.ContextVar[Optional[int]] = contextvars.ContextVar(
+    "cda_log_iteration", default=None
+)
+
+#: Substituted for the iteration when it is unknown. Not "0", which is a real
+#: iteration number, and not "" which would make the field vanish and misalign
+#: every line.
+_NO_ITERATION = "-"
+
+
+def set_iteration(iteration: Optional[int]) -> None:
+    """Tag subsequent log lines in this process with a training iteration.
+
+    Lets a line in the run log be joined to the `progress.jsonl` row for the
+    same iteration, which was previously guesswork: the file is keyed by
+    iteration and the log was keyed by nothing.
+
+    Pass None to clear it, which is what a process that has stopped training
+    should do rather than leave a stale number on unrelated lines.
+    """
+    _iteration.set(iteration)
+
+
+def current_iteration() -> Optional[int]:
+    """The iteration tagging this process's log lines, or None."""
+    return _iteration.get()
+
+
+def log_file_path() -> Optional[str]:
+    """The run log this process writes, or None if it logs only to stdout."""
+    return _log_file_path
+
+
+class _IterationFilter(logging.Filter):
+    """Give every record an `iteration` attribute so the format can use it.
+
+    Attached to the handlers rather than to the logger: a filter on a logger
+    only sees records logged directly to it, while every record from a child
+    module logger reaches the handler. Without this, one line from a module
+    that never sets an iteration would raise a formatting error rather than
+    print a dash.
+    """
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        iteration = _iteration.get()
+        record.iteration = _NO_ITERATION if iteration is None else iteration
+        return True
 
 
 def _settings() -> dict:
@@ -61,6 +117,16 @@ def _settings() -> dict:
 def level_env_var() -> str:
     """Name of the environment variable that carries the level to workers."""
     return _settings()["env_var"]
+
+
+def log_dir_env_var() -> str:
+    """Name of the environment variable carrying the log directory to workers.
+
+    The companion of `level_env_var`, and for the same reason: an env runner is
+    a separate interpreter that never runs `train.main`, so anything the driver
+    decided has to travel through the environment to reach it.
+    """
+    return _settings()["dir_env_var"]
 
 
 def resolve_level(level: Optional[str] = None) -> str:
@@ -79,8 +145,13 @@ def resolve_level(level: Optional[str] = None) -> str:
     return str(_settings()["level"]).upper()
 
 
-def configure(level: Optional[str] = None, *, force: bool = False) -> str:
-    """Attach the package handler and set the level. Idempotent per process.
+def configure(
+    level: Optional[str] = None,
+    *,
+    log_dir: Optional[str] = None,
+    force: bool = False,
+) -> str:
+    """Attach the package handlers and set the level. Idempotent per process.
 
     Also exports the resolved level into the environment, so Ray workers
     started after this call inherit it. Returns the level applied.
@@ -88,26 +159,105 @@ def configure(level: Optional[str] = None, *, force: bool = False) -> str:
     `force` reconfigures a process that is already set up, which is what a
     caller that has just parsed a new level needs; ordinary `get_logger` calls
     leave an existing configuration alone.
+
+    `log_dir` adds a rotating file handler writing `<log_dir>/<file_name>`,
+    beside `progress.jsonl`, and exports the directory so the Ray workers
+    started afterwards write there too. A worker resolves it from the
+    environment and writes its own pid-suffixed file; passing no `log_dir` and
+    having no exported one means stdout only, which is what a bare import gets.
+
+    Each process writes a separate file on purpose. `RotatingFileHandler` is
+    not safe across processes - two of them crossing the size threshold
+    together rename and truncate the same file underneath each other - and
+    sharing one is not optional-but-nice here: the episode callbacks run on the
+    env runners, so with `num_env_runners > 0` the NAV tables and the
+    conservation ERROR are emitted in a worker and would otherwise reach no
+    file at all.
     """
-    global _configured
+    global _configured, _log_file_path
 
     settings = _settings()
     resolved = resolve_level(level)
 
+    # A worker never runs train.main, so the directory reaches it the same way
+    # the level does. `own_file` keeps the driver on the plain name.
+    own_file = log_dir is not None
+    if log_dir is None:
+        log_dir = os.environ.get(log_dir_env_var()) or None
+
     root = logging.getLogger(ROOT_NAME)
     if not _configured or force:
         for handler in list(root.handlers):
+            handler.close()
             root.removeHandler(handler)
-        handler = logging.StreamHandler()
-        handler.setFormatter(
-            logging.Formatter(settings["format"], datefmt=settings["datefmt"])
+        _log_file_path = None
+
+        formatter = logging.Formatter(
+            settings["format"], datefmt=settings["datefmt"]
         )
-        root.addHandler(handler)
+        iteration_filter = _IterationFilter()
+
+        stream = logging.StreamHandler()
+        stream.setFormatter(formatter)
+        stream.addFilter(iteration_filter)
+        root.addHandler(stream)
+
+        if log_dir:
+            file_handler = _build_file_handler(log_dir, settings, own_file)
+            if file_handler is not None:
+                file_handler.setFormatter(formatter)
+                file_handler.addFilter(iteration_filter)
+                root.addHandler(file_handler)
+
         _configured = True
 
     root.setLevel(resolved)
     os.environ[level_env_var()] = resolved
+    if log_dir:
+        os.environ[log_dir_env_var()] = os.path.abspath(log_dir)
     return resolved
+
+
+def _build_file_handler(log_dir: str, settings: dict, own_file: bool):
+    """A rotating handler under `log_dir`, or None if file logging is off.
+
+    A failure to open the file is a warning, not an exception. Logging is
+    instrumentation: a run that cannot write its log should still train, the
+    same way `_append_progress` refuses to take down a run that is otherwise
+    fine. The warning goes to the stream handler, which is already attached.
+    """
+    global _log_file_path
+
+    file_name = settings.get("file_name")
+    if not file_name:
+        return None
+
+    if not own_file:
+        # A worker: same name with its pid before the suffix, so run.log has
+        # run.4231.log beside it rather than several processes fighting over
+        # one inode.
+        stem, suffix = os.path.splitext(file_name)
+        file_name = f"{stem}.{os.getpid()}{suffix}"
+
+    path = os.path.join(os.path.abspath(log_dir), file_name)
+    try:
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        handler = logging.handlers.RotatingFileHandler(
+            path,
+            maxBytes=settings["file_max_bytes"],
+            backupCount=settings["file_backup_count"],
+            encoding="utf-8",
+            delay=True,
+        )
+    except OSError:
+        logging.getLogger(ROOT_NAME).warning(
+            "could not open the run log at %s - continuing with stdout only",
+            path, exc_info=True,
+        )
+        return None
+
+    _log_file_path = path
+    return handler
 
 
 def get_logger(name: str) -> logging.Logger:

--- a/gym_continuousDoubleAuction/test/test_activity_metrics.py
+++ b/gym_continuousDoubleAuction/test/test_activity_metrics.py
@@ -1,0 +1,244 @@
+"""The two behaviours a return series cannot tell apart.
+
+An agent that stops trading looks the same in its returns whether it *chose*
+to pass or whether every order it sent was refused for want of cash. Both
+produce a flat, unremarkable line.
+
+The first case is S1-3: `entropy_coeff` is 0.0, so policies can collapse to
+always-pass, and such a policy still clears the champion promotion threshold
+because 0 beats a negative league mean. The pool then fills with snapshots of
+the do-nothing policy while nothing in the logs says so. `pass_action_fraction`
+trending to 1.0 says it outright.
+
+The second is a policy quoting past its cash every step. `order_step_placed`
+cannot express it: that flag is 0 both for an agent that never tried and for
+one whose order was rejected.
+
+See doc/11 2.2 and 4.
+"""
+import os
+import pickle
+import sys
+from unittest.mock import MagicMock
+
+import pytest
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '../..')))
+
+from gym_continuousDoubleAuction.train.callbk.league_based_self_play_callback import (
+    SelfPlayCallback,
+)
+
+NUM_AGENTS = 4
+
+
+class MockEpisode:
+    def __init__(self, episode_id, infos=None):
+        self.id_ = episode_id
+        self._infos = infos or {}
+
+    def get_infos(self, index):
+        return self._infos if index == -1 else {}
+
+    # on_episode_step reads these for the pickle store; empty is fine.
+    def get_observations(self, index):
+        return {}
+
+    def get_actions(self, index):
+        return {}
+
+    def get_rewards(self, index):
+        return {}
+
+
+def _infos(passes=0, rejections=0, agents=NUM_AGENTS):
+    """One step's infos: `passes` agents passed, `rejections` were refused."""
+    out = {}
+    for i in range(agents):
+        out[f"agent_{i}"] = {
+            "is_pass_action": i < passes,
+            "num_rejected_step": 1 if i < rejections else 0,
+        }
+    return out
+
+
+class ActivityHarness:
+    """Drives the three episode hooks without RLlib."""
+
+    def __init__(self, **kwargs):
+        kwargs.setdefault("episode_data_dir", None)
+        self.callback = SelfPlayCallback(
+            num_trainable_policies=2, num_random_policies=2, **kwargs
+        )
+        self.metrics = MagicMock()
+        self.env_runner = MagicMock()
+
+    def _hook_args(self, episode):
+        return dict(
+            episode=episode, env_runner=self.env_runner,
+            metrics_logger=self.metrics, env=MagicMock(), env_index=0,
+            rl_module=None,
+        )
+
+    def start(self, episode_id):
+        self.callback.on_episode_start(**self._hook_args(MockEpisode(episode_id)))
+
+    def step(self, episode_id, infos):
+        self.callback.on_episode_step(
+            **self._hook_args(MockEpisode(episode_id, infos))
+        )
+
+    def end(self, episode_id):
+        """Only the activity part - the NAV check needs its own scaffolding."""
+        self.callback._log_activity(MockEpisode(episode_id), self.metrics)
+
+    def emitted(self, name):
+        for call in self.metrics.log_value.call_args_list:
+            if call.args and call.args[0] == name:
+                return call
+        return None
+
+
+class TestPassActionFraction:
+
+    def test_a_fully_passive_episode_reports_one(self):
+        """The S1-3 signature. This is the number that would have made the
+        collapse visible instead of leaving it to be inferred."""
+        h = ActivityHarness()
+        h.start("ep")
+        for _ in range(10):
+            h.step("ep", _infos(passes=NUM_AGENTS))
+        h.end("ep")
+
+        call = h.emitted("pass_action_fraction")
+        assert call is not None
+        assert call.args[1] == pytest.approx(1.0)
+        assert call.kwargs["window"] == 10
+
+    def test_a_fully_active_episode_reports_zero(self):
+        h = ActivityHarness()
+        h.start("ep")
+        for _ in range(10):
+            h.step("ep", _infos(passes=0))
+        h.end("ep")
+
+        assert h.emitted("pass_action_fraction").args[1] == pytest.approx(0.0)
+
+    def test_the_fraction_is_over_agent_steps(self):
+        """Half the agents passing every step is 0.5, whatever the step count -
+        a fraction so the number means the same at any num_agents or max_step."""
+        h = ActivityHarness()
+        h.start("ep")
+        for _ in range(7):
+            h.step("ep", _infos(passes=2))
+        h.end("ep")
+
+        assert h.emitted("pass_action_fraction").args[1] == pytest.approx(0.5)
+
+
+class TestOrderRejectionFraction:
+
+    def test_rejections_are_counted(self):
+        h = ActivityHarness()
+        h.start("ep")
+        for _ in range(5):
+            h.step("ep", _infos(rejections=NUM_AGENTS))
+        h.end("ep")
+
+        call = h.emitted("order_rejection_fraction")
+        assert call is not None
+        assert call.args[1] == pytest.approx(1.0)
+
+    def test_it_is_independent_of_passing(self):
+        """The distinction the metric exists for: nobody passed, yet nothing
+        reached the book."""
+        h = ActivityHarness()
+        h.start("ep")
+        for _ in range(5):
+            h.step("ep", _infos(passes=0, rejections=NUM_AGENTS))
+        h.end("ep")
+
+        assert h.emitted("pass_action_fraction").args[1] == pytest.approx(0.0)
+        assert h.emitted("order_rejection_fraction").args[1] == pytest.approx(1.0)
+
+
+class TestBookkeeping:
+
+    def test_an_episode_with_no_infos_emits_nothing(self):
+        """0.0 would read as 'nothing passed', a claim about behaviour that an
+        episode reporting no agent infos gives no evidence for."""
+        h = ActivityHarness()
+        h.start("ep")
+        h.end("ep")
+
+        assert h.emitted("pass_action_fraction") is None
+        assert h.emitted("order_rejection_fraction") is None
+
+    def test_the_tally_is_released_at_episode_end(self):
+        """One entry per live episode; a leak here grows with every episode a
+        long run plays."""
+        h = ActivityHarness()
+        h.start("ep")
+        h.step("ep", _infos(passes=1))
+        assert "ep" in h.callback._activity
+
+        h.end("ep")
+        assert "ep" not in h.callback._activity
+
+    def test_concurrent_episodes_do_not_mix(self):
+        """Keyed by episode ID, like `store`: under a vectorised runner two
+        episodes are in flight at once."""
+        h = ActivityHarness()
+        h.start("a")
+        h.start("b")
+        for _ in range(4):
+            h.step("a", _infos(passes=NUM_AGENTS))   # a: all passing
+            h.step("b", _infos(passes=0))            # b: none passing
+        h.end("a")
+        a_value = h.emitted("pass_action_fraction").args[1]
+        h.metrics.reset_mock()
+        h.end("b")
+        b_value = h.emitted("pass_action_fraction").args[1]
+
+        assert a_value == pytest.approx(1.0)
+        assert b_value == pytest.approx(0.0)
+
+    def test_a_step_without_a_start_does_not_raise(self):
+        """A restored run picks up mid-flight, so on_episode_start may never
+        have run for an episode this worker reports on. A missing counter must
+        not take down training for the sake of a metric."""
+        h = ActivityHarness()
+        h.step("never-started", _infos(passes=NUM_AGENTS))
+        h.end("never-started")
+
+        assert h.emitted("pass_action_fraction").args[1] == pytest.approx(1.0)
+
+    def test_it_does_not_depend_on_the_pickle_store(self):
+        """episode_data_dir=None is a supported configuration, and these
+        metrics are counted independently of that dump."""
+        h = ActivityHarness(episode_data_dir=None)
+        h.start("ep")
+        for _ in range(3):
+            h.step("ep", _infos(passes=NUM_AGENTS))
+        h.end("ep")
+
+        assert h.callback.episode_data_dir is None
+        assert h.emitted("pass_action_fraction").args[1] == pytest.approx(1.0)
+
+    def test_no_metrics_logger_is_tolerated(self):
+        h = ActivityHarness()
+        h.start("ep")
+        h.step("ep", _infos(passes=1))
+        h.callback._log_activity(MockEpisode("ep"), None)
+
+        assert "ep" not in h.callback._activity   # still released
+
+    def test_the_callback_still_pickles(self):
+        """It is cloudpickled into every checkpoint. A defaultdict with a lambda
+        factory would pass every test above and fail on restore."""
+        h = ActivityHarness()
+        h.start("ep")
+        h.step("ep", _infos(passes=2))
+
+        revived = pickle.loads(pickle.dumps(h.callback))
+        assert revived._activity["ep"]["passes"] == 2

--- a/gym_continuousDoubleAuction/test/test_info_dict.py
+++ b/gym_continuousDoubleAuction/test/test_info_dict.py
@@ -306,3 +306,74 @@ class TestSerialisation:
         assert _plain("1000.5") == "1000.5"
         assert _plain(None) is None
         assert _plain(3) == 3
+
+
+class TestActivityFields:
+    """doc/11 2.2: the two things a return series cannot distinguish."""
+
+    def test_both_fields_are_present(self, stepped_env):
+        _, infos, _, _ = stepped_env
+        for i in range(NUM_AGENTS):
+            info = infos[f"agent_{i}"]
+            assert isinstance(info["is_pass_action"], bool)
+            assert isinstance(info["num_rejected_step"], int)
+
+    def test_is_pass_action_agrees_with_the_category_encoding(self, stepped_env):
+        """The flag exists so a reader of `info` need not know that category 0
+        means pass - _CATEGORY_MAP owns that. It must still agree with it.
+        """
+        _, _, _, every_info = stepped_env
+        checked = 0
+        for infos in every_info:
+            for i in range(NUM_AGENTS):
+                info = infos[f"agent_{i}"]
+                category = info.get("model_action", {}).get("category")
+                if category is None:
+                    continue
+                checked += 1
+                assert info["is_pass_action"] == (category == 0), (
+                    f"agent_{i}: is_pass_action={info['is_pass_action']} but "
+                    f"category={category}"
+                )
+        assert checked, "no model actions were available to cross-check"
+
+    def test_passing_is_observed_at_all(self, stepped_env):
+        """Uniform random actions over the category space should pass sometimes;
+        a flag that is never True would be indistinguishable from a broken one.
+        """
+        _, _, _, every_info = stepped_env
+        assert any(
+            infos[f"agent_{i}"]["is_pass_action"]
+            for infos in every_info for i in range(NUM_AGENTS)
+        )
+
+    def test_rejections_are_counted_when_cash_runs_out(self):
+        """The counter must be able to fire. With init_cash this small most
+        orders cannot be afforded, so refusals are the common case - measured at
+        151 of 200 agent-steps when this was written.
+        """
+        env = continuousDoubleAuctionEnv({
+            "num_of_agents": NUM_AGENTS,
+            "init_cash": 500,
+            "tick_size": 1,
+            "tape_display_length": 10,
+            "max_step": 60,
+        })
+        env.reset()
+        rejections = 0
+        for _ in range(30):
+            actions = {
+                f"agent_{i}": env.action_spaces[f"agent_{i}"].sample()
+                for i in range(NUM_AGENTS)
+            }
+            _, _, terminateds, truncateds, infos = env.step(actions)
+            rejections += sum(
+                infos[f"agent_{i}"]["num_rejected_step"] for i in range(NUM_AGENTS)
+            )
+            if terminateds.get("__all__") or truncateds.get("__all__"):
+                break
+
+        assert rejections > 0, (
+            "no order was refused even at init_cash=500: num_rejected_step "
+            "would be a counter that is always 0"
+        )

--- a/gym_continuousDoubleAuction/test/test_logging_setup.py
+++ b/gym_continuousDoubleAuction/test/test_logging_setup.py
@@ -29,12 +29,27 @@ def restore_logging():
     saved_handlers = list(root.handlers)
     saved_level = root.level
     saved_configured = logging_setup._configured
+    saved_log_file = logging_setup._log_file_path
+    # configure(log_dir=...) exports the directory for worker processes. Left
+    # set, the next test to call configure() would resolve it from the
+    # environment and write a file into a tmp_path that no longer exists.
+    import os as _os
+    saved_dir_var = _os.environ.get(logging_setup.log_dir_env_var())
 
     yield
 
+    for handler in list(root.handlers):
+        if handler not in saved_handlers:
+            handler.close()   # release the run log before tmp_path is removed
     root.handlers = saved_handlers
     root.setLevel(saved_level)
     logging_setup._configured = saved_configured
+    logging_setup._log_file_path = saved_log_file
+    logging_setup.set_iteration(None)
+    if saved_dir_var is None:
+        _os.environ.pop(logging_setup.log_dir_env_var(), None)
+    else:
+        _os.environ[logging_setup.log_dir_env_var()] = saved_dir_var
     config_loader.reload()
 
 
@@ -162,3 +177,220 @@ class TestPackageModulesUseIt:
                 if call.search(stripped):
                     offenders.append(f"{path.relative_to(root)}:{number}")
         assert offenders == []
+
+
+class TestRunLogFile:
+    """The log survives the terminal it was printed in.
+
+    Until this existed the package logged only to stdout, so the narrative a
+    run is diagnosed from - the per-episode NAV tables, the ERROR preceding a
+    strict_nav_check raise - lived in scrollback, while progress.jsonl kept the
+    numbers. doc/17 17 records two GPU runs diagnosed exactly that way.
+    """
+
+    def test_a_run_log_is_written_beside_the_metrics(self, tmp_path):
+        logging_setup.configure("INFO", log_dir=str(tmp_path), force=True)
+        logging_setup.get_logger("gym_continuousDoubleAuction.t").info("hello")
+
+        path = tmp_path / "run.log"
+        assert path.exists()
+        assert "hello" in path.read_text()
+        assert logging_setup.log_file_path() == str(path)
+
+    def test_the_file_gets_what_stdout_gets(self, tmp_path, capsys):
+        logging_setup.configure("INFO", log_dir=str(tmp_path), force=True)
+        logging_setup.get_logger("gym_continuousDoubleAuction.t").warning("both")
+
+        assert "both" in capsys.readouterr().err
+        assert "both" in (tmp_path / "run.log").read_text()
+
+    def test_no_file_without_a_log_dir(self, tmp_path):
+        """Every env runner takes this path: RotatingFileHandler is not safe
+        across processes, so only the driver passes a directory."""
+        logging_setup.configure("INFO", force=True)
+        logging_setup.get_logger("gym_continuousDoubleAuction.t").info("stdout only")
+
+        assert logging_setup.log_file_path() is None
+        assert not list(tmp_path.glob("*.log*"))
+
+    def test_rotation_bounds_the_file(self, tmp_path, config_tree):
+        """doc/11 3 lists unbounded growth as a persistence problem; a run log
+        that fills the disk would be a new instance of it."""
+        config_tree("tunable_constants.json", lambda raw: raw["logging"].update(
+            {"file_max_bytes": 2048, "file_backup_count": 2}
+        ))
+        logging_setup.configure("INFO", log_dir=str(tmp_path), force=True)
+        logger = logging_setup.get_logger("gym_continuousDoubleAuction.t")
+
+        for i in range(400):
+            logger.info("filling the log with line %s of padding", i)
+
+        logs = sorted(p.name for p in tmp_path.glob("run.log*"))
+        assert logs, "nothing was written"
+        # 1 live file + at most backup_count rotated ones, and none oversized
+        assert len(logs) <= 3, logs
+        for name in logs:
+            assert (tmp_path / name).stat().st_size < 8192, name
+
+    def test_an_empty_file_name_disables_it(self, tmp_path, config_tree):
+        config_tree("tunable_constants.json",
+                    lambda raw: raw["logging"].update({"file_name": ""}))
+        logging_setup.configure("INFO", log_dir=str(tmp_path), force=True)
+        logging_setup.get_logger("gym_continuousDoubleAuction.t").info("nowhere")
+
+        assert logging_setup.log_file_path() is None
+        assert not list(tmp_path.glob("*.log*"))
+
+    def test_an_unwritable_destination_warns_and_keeps_training(self, tmp_path):
+        """Instrumentation must not take down a run that is otherwise fine -
+        the same rule _append_progress follows."""
+        blocked = tmp_path / "not-a-dir"
+        blocked.write_text("this is a file, so it cannot contain run.log")
+
+        logging_setup.configure("INFO", log_dir=str(blocked), force=True)
+
+        assert logging_setup.log_file_path() is None
+        logging_setup.get_logger("gym_continuousDoubleAuction.t").info("still up")
+
+    def test_the_file_name_and_bounds_come_from_the_file(self, tmp_path, config_tree):
+        """No literal copy in Python - the property doc/18 claims."""
+        config_tree("tunable_constants.json", lambda raw: raw["logging"].update(
+            {"file_name": "renamed.log"}
+        ))
+        logging_setup.configure("INFO", log_dir=str(tmp_path), force=True)
+        logging_setup.get_logger("gym_continuousDoubleAuction.t").info("x")
+
+        assert (tmp_path / "renamed.log").exists()
+
+
+class TestIterationTag:
+    """A log line can be joined to its progress.jsonl row."""
+
+    def test_lines_carry_the_iteration(self, tmp_path):
+        logging_setup.configure("INFO", log_dir=str(tmp_path), force=True)
+        logger = logging_setup.get_logger("gym_continuousDoubleAuction.t")
+
+        logging_setup.set_iteration(12)
+        logger.info("inside twelve")
+
+        assert "iter=12" in (tmp_path / "run.log").read_text()
+
+    def test_an_unknown_iteration_is_a_dash(self, tmp_path):
+        """Every env runner is in this state. It must not be '0', which is a
+        real iteration, and must not blow up formatting."""
+        logging_setup.configure("INFO", log_dir=str(tmp_path), force=True)
+        logging_setup.get_logger("gym_continuousDoubleAuction.t").info("no idea")
+
+        assert "iter=-" in (tmp_path / "run.log").read_text()
+
+    def test_clearing_it_stops_the_tagging(self, tmp_path):
+        logging_setup.configure("INFO", log_dir=str(tmp_path), force=True)
+        logger = logging_setup.get_logger("gym_continuousDoubleAuction.t")
+
+        logging_setup.set_iteration(3)
+        logger.info("during")
+        logging_setup.set_iteration(None)
+        logger.info("after")
+
+        lines = (tmp_path / "run.log").read_text().splitlines()
+        assert "iter=3" in lines[0]
+        assert "iter=-" in lines[1]
+
+    def test_a_child_module_logger_is_tagged_too(self, tmp_path):
+        """The filter is on the handler, not the logger: a filter on the
+        package logger would miss everything propagating up from a child."""
+        logging_setup.configure("INFO", log_dir=str(tmp_path), force=True)
+        logging_setup.set_iteration(5)
+
+        logging_setup.get_logger(
+            "gym_continuousDoubleAuction.envs.exchg.info_helper"
+        ).info("from a child")
+
+        assert "iter=5" in (tmp_path / "run.log").read_text()
+
+    def test_current_iteration_reports_it(self):
+        logging_setup.set_iteration(9)
+        assert logging_setup.current_iteration() == 9
+        logging_setup.set_iteration(None)
+        assert logging_setup.current_iteration() is None
+
+
+class TestTimestampsAreOrderable:
+
+    def test_the_date_is_in_the_stamp(self, tmp_path):
+        """A training run outlasts a day; a time-only stamp cannot be ordered
+        across midnight, nor joined to anything dated."""
+        import re
+
+        logging_setup.configure("INFO", log_dir=str(tmp_path), force=True)
+        logging_setup.get_logger("gym_continuousDoubleAuction.t").info("when")
+
+        first = (tmp_path / "run.log").read_text().splitlines()[0]
+        assert re.match(r"^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\b", first), first
+
+
+class TestWorkerProcessesGetTheirOwn:
+    """The episode callbacks run on the env runners, not the driver.
+
+    With num_env_runners > 0 the NAV tables and the conservation ERROR are
+    emitted in a worker. A driver-only file would miss exactly the lines this
+    whole feature exists to keep. Verified against a real 2-runner training run:
+    without this the worker's NAV tables reached no file at all.
+    """
+
+    def test_the_directory_is_exported_for_workers(self, tmp_path):
+        import os
+
+        logging_setup.configure("INFO", log_dir=str(tmp_path), force=True)
+
+        assert os.environ[logging_setup.log_dir_env_var()] == str(tmp_path)
+
+    def test_a_worker_resolves_the_directory_from_the_environment(
+        self, tmp_path, monkeypatch
+    ):
+        """A worker never runs train.main, so this is the only channel it has -
+        the same route the level takes."""
+        monkeypatch.setenv(logging_setup.log_dir_env_var(), str(tmp_path))
+
+        logging_setup.configure("INFO", force=True)   # no log_dir: a worker
+        logging_setup.get_logger("gym_continuousDoubleAuction.t").info("worker line")
+
+        written = list(tmp_path.glob("run.*.log"))
+        assert len(written) == 1, [p.name for p in written]
+        assert "worker line" in written[0].read_text()
+
+    def test_a_worker_writes_its_own_pid_suffixed_file(self, tmp_path, monkeypatch):
+        """Separate files, not one shared: RotatingFileHandler is not safe
+        across processes, and two workers rotating together truncate each
+        other's output."""
+        import os
+
+        monkeypatch.setenv(logging_setup.log_dir_env_var(), str(tmp_path))
+        logging_setup.configure("INFO", force=True)
+        logging_setup.get_logger("gym_continuousDoubleAuction.t").info("x")
+
+        assert logging_setup.log_file_path() == str(
+            tmp_path / f"run.{os.getpid()}.log"
+        )
+        assert not (tmp_path / "run.log").exists()
+
+    def test_the_driver_keeps_the_plain_name(self, tmp_path):
+        """Passing log_dir explicitly is what makes a process the driver."""
+        logging_setup.configure("INFO", log_dir=str(tmp_path), force=True)
+        logging_setup.get_logger("gym_continuousDoubleAuction.t").info("x")
+
+        assert logging_setup.log_file_path() == str(tmp_path / "run.log")
+
+    def test_the_variable_name_comes_from_the_file(self, config_tree):
+        config_tree("tunable_constants.json", lambda raw: raw["logging"].update(
+            {"dir_env_var": "CDA_OTHER_DIR"}
+        ))
+        assert logging_setup.log_dir_env_var() == "CDA_OTHER_DIR"
+
+    def test_no_file_when_nothing_points_anywhere(self, tmp_path, monkeypatch):
+        monkeypatch.delenv(logging_setup.log_dir_env_var(), raising=False)
+        logging_setup.configure("INFO", force=True)
+        logging_setup.get_logger("gym_continuousDoubleAuction.t").info("x")
+
+        assert logging_setup.log_file_path() is None
+        assert not list(tmp_path.glob("*.log*"))

--- a/gym_continuousDoubleAuction/train/callbk/league_based_self_play_callback.py
+++ b/gym_continuousDoubleAuction/train/callbk/league_based_self_play_callback.py
@@ -143,6 +143,70 @@ class SelfPlayCallback(RLlibCallback):
         # `on_episode_end` reset the shared list to None.
         self.store = defaultdict(list)
 
+        # Per-episode activity tallies, keyed by episode ID like `store`, so
+        # concurrent episodes under a vectorised runner cannot mix.
+        #
+        # A plain dict, not defaultdict(lambda: ...): this callback is
+        # cloudpickled into every checkpoint, and a lambda default_factory is
+        # the kind of thing that survives locally and fails on a restore path
+        # nobody exercised. Three ints per live episode - the memory is nothing
+        # next to `store`.
+        self._activity = {}
+
+
+    def _log_activity(self, episode, metrics_logger) -> None:
+        """Emit the episode's pass and rejection fractions, then drop the tally.
+
+        `pass_action_fraction` is the metric S1-3 needs. A league whose policies
+        collapse to always-pass still clears the promotion threshold, because 0
+        beats a negative mean, so the pool fills with snapshots of the
+        do-nothing policy and the returns series looks unremarkable while it
+        happens. A fraction trending to 1.0 says it outright.
+
+        `order_rejection_fraction` separates the other case returns cannot
+        distinguish: an agent that is not trading because it chose not to, from
+        one whose every order is refused for want of cash.
+
+        Fractions rather than counts, so the numbers mean the same thing at any
+        `num_agents` or `max_step`. window=10 matches the league metrics: a
+        single episode's fraction is noisy, and the question is the trend.
+        """
+        tally = self._activity.pop(episode.id_, None)
+        if not tally or not metrics_logger:
+            return
+
+        agent_steps = tally["agent_steps"]
+        if agent_steps <= 0:
+            # An episode reporting no agent infos at all. Emitting 0.0 here
+            # would read as "nothing passed", which is a claim about behaviour
+            # this episode gives no evidence for.
+            return
+
+        pass_fraction = tally["passes"] / agent_steps
+        rejection_fraction = tally["rejections"] / agent_steps
+
+        metrics_logger.log_value("pass_action_fraction", pass_fraction, window=10)
+        metrics_logger.log_value(
+            "order_rejection_fraction", rejection_fraction, window=10
+        )
+
+        logger.debug(
+            "episode %s activity: %s agent-steps, %.1f%% pass, %.1f%% rejected",
+            episode.id_, agent_steps, 100 * pass_fraction,
+            100 * rejection_fraction,
+        )
+
+    def _activity_for(self, episode_id) -> dict:
+        """The tally for this episode, created if the start hook missed it.
+
+        `on_episode_start` is not guaranteed to have run for every episode a
+        worker reports on - a restored run picks up mid-flight - and a counter
+        that raises KeyError would take down training for the sake of a metric.
+        """
+        return self._activity.setdefault(
+            episode_id, {"agent_steps": 0, "passes": 0, "rejections": 0}
+        )
+
 
     def on_episode_start(
         self,
@@ -184,6 +248,9 @@ class SelfPlayCallback(RLlibCallback):
             logger.debug("episode %s started, policy map: %s", episode.id_, mapping)
 
         self.store[episode.id_] = []
+        self._activity[episode.id_] = {
+            "agent_steps": 0, "passes": 0, "rejections": 0,
+        }
 
     def on_episode_step(
         self,
@@ -236,6 +303,19 @@ class SelfPlayCallback(RLlibCallback):
         }
         self.store[episode.id_].append(step_data)
 
+        # Tally activity as the episode runs. Counted here rather than from
+        # `store` at episode end because `store` is only populated when
+        # episode_data_dir is set, and these metrics must not depend on the
+        # pickle dump being switched on.
+        tally = self._activity_for(episode.id_)
+        for agent_info in (last_info or {}).values():
+            if not isinstance(agent_info, dict):
+                continue
+            tally["agent_steps"] += 1
+            if agent_info.get("is_pass_action"):
+                tally["passes"] += 1
+            tally["rejections"] += int(agent_info.get("num_rejected_step", 0) or 0)
+
     def on_episode_end(
         self,
         *,
@@ -262,6 +342,8 @@ class SelfPlayCallback(RLlibCallback):
 
         # Always release the memory, whether or not we wrote it out.
         self.store.pop(episode.id_, None)
+
+        self._log_activity(episode, metrics_logger)
 
         # Try to get parameters from different possible sources. The starting
         # points are the env's own fallback for init_cash and the league size

--- a/gym_continuousDoubleAuction/train/train.py
+++ b/gym_continuousDoubleAuction/train/train.py
@@ -41,6 +41,7 @@ from gym_continuousDoubleAuction.envs.continuousDoubleAuction_env import (
 )
 from gym_continuousDoubleAuction.logging_setup import configure as configure_logging
 from gym_continuousDoubleAuction.logging_setup import get_logger
+from gym_continuousDoubleAuction.logging_setup import log_file_path, set_iteration
 from gym_continuousDoubleAuction.train.callbk.league_based_self_play_callback import (
     SelfPlayCallback,
 )
@@ -929,8 +930,14 @@ def train(cfg: TrainConfig) -> Tuple[Algorithm, dict]:
     saved_at = None
     result: dict = {}
     for _ in range(target - start):
+        # Provisional, so anything the driver logs *during* the iteration is
+        # tagged with the one being worked on rather than the one before it.
+        # RLlib's own count is authoritative and replaces it below; the two
+        # agree unless a restore left the counter somewhere unexpected.
+        set_iteration(iteration + 1)
         result = algo.train()
         iteration = int(result.get("training_iteration", iteration + 1))
+        set_iteration(iteration)
         _log_iteration(iteration, target, result, cfg)
         _append_progress(result, cfg)
 
@@ -1182,7 +1189,13 @@ def main(argv=None) -> None:
     # one. force=True because importing this module already configured the
     # process from the environment or the config default, and the level just
     # parsed from the command line is the one the user asked for.
-    configure_logging(cfg.cda_log_level, force=True)
+    #
+    # log_dir is passed only here, and only by the driver: it adds the rotating
+    # run log beside progress.jsonl, and RotatingFileHandler cannot be shared
+    # across processes without workers racing each other's rotations.
+    configure_logging(cfg.cda_log_level, log_dir=cfg.log_base_dir, force=True)
+    if log_file_path():
+        logger.info("run log: %s", log_file_path())
 
     # Shared with the notebook, which has to export these before it imports
     # ray. Imported here rather than at module scope: runtime.py reads
@@ -1195,6 +1208,9 @@ def main(argv=None) -> None:
     try:
         train(cfg)
     finally:
+        # Shutdown is not part of any iteration; leaving the last one set would
+        # tag teardown lines with a number they had nothing to do with.
+        set_iteration(None)
         ray.shutdown()
 
 


### PR DESCRIPTION
Two earlier changes gave the run and the step machine-readable histories.
The log itself still went only to stdout: there was one addHandler call
in the package and it attached a StreamHandler. So a finished run left
its numbers on disk and its narrative in scrollback - the per-episode NAV
tables, the league statistics, the ERROR that immediately precedes a
strict_nav_check raise. doc/17 17 records two GPU runs diagnosed exactly
that way, after the fact, from a terminal buffer.

Every process now writes a rotating file under log_base_dir, beside
progress.jsonl: run.log from the driver, run.<pid>.log from each env
runner. file_max_bytes and file_backup_count bound it, so it does not
re-create the unbounded growth doc/11 3 lists for the episode pickles. A
failure to open it warns rather than raising - instrumentation must not
take down a run that is otherwise training.

One file per process is not a detail, and measuring it changed the
design. The first version wrote from the driver only, reasoning that
RotatingFileHandler is unsafe across processes and Ray captures worker
stdout anyway. A real two-runner run showed the cost: the driver file
held 7 lines and not one NAV table. The episode callbacks run on the env
runners, so with num_env_runners > 0 the NAV tables and the conservation
ERROR are emitted in a worker and reach no file at all - and the shipped
runtime profiles use num_env_runners=2. Per-process files keep those
lines and sidestep the rotation race, since no two processes share an
inode. log_base_dir travels to workers through $CDA_LOG_DIR, the channel
the level already uses.

Timestamps carry the date. datefmt was "%H:%M:%S", and a run outlasts a
day, so a time-only stamp cannot be ordered across midnight.

Lines carry the training iteration. progress.jsonl is keyed by iteration
and the log was keyed by nothing, so relating them meant matching on
wall-clock order. iter=<n> comes from a ContextVar - per-thread, not a
module global - injected by a filter on the handlers rather than the
logger, because a filter on the package logger never sees records
propagating up from a child module. Unknown reads "-", not "0", which is
a real iteration number.

The limit, stated rather than hidden: with remote runners a worker's NAV
table is dated, attributed and durable but reads iter=-. The worker does
not know which iteration its episode belongs to, and fixing that means
changing what RLlib hands the callbacks.

test_logging_setup grows from 10 tests to 29. Two isolation hazards the
new ones introduced are handled in the fixture: file handles are closed
before pytest removes the tmp_path they point into, and $CDA_LOG_DIR is
restored, since configure now exports it and a leaked value would send
the next test's output into a directory that no longer exists.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01K2C8fZ7CPpwRjFk7oUcXvm