### PR TITLE
Fix five defects found in a code review of the simulator's edges

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,3 +41,69 @@ jobs:
         # This is the test that would have caught the silently-ignored
         # RandomPolicy and the champion weights never reaching the EnvRunners.
         run: python -m pytest gym_continuousDoubleAuction/test/integration -q
+
+
+  # Every job above installs the full requirements.txt from a checkout, so none
+  # of them can see what a *user* gets from `pip install`. That is why both
+  # halves of doc/15 S3-6/S3-18 went unnoticed: install_requires did not name
+  # ray[rllib], scikit-learn or six, and no config JSON was in the distribution
+  # at all - so an installed copy raised FileNotFoundError on import, while CI
+  # stayed green. This job is the missing coverage: build the wheel, install it
+  # somewhere with no repo and no requirements.txt, and construct an env.
+  packaging:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Build the wheel
+        run: |
+          python -m pip install --upgrade pip build
+          python -m build --wheel --outdir dist
+
+      - name: The wheel must carry the config tree
+        # config/ lives at the repo root, outside the package; setup.py's
+        # build_py stages it in. If that staging stops working the failure is
+        # otherwise silent until someone installs the result.
+        run: |
+          python - <<'PY'
+          import glob, sys, zipfile
+          wheel = glob.glob("dist/*.whl")[0]
+          shipped = sorted(
+              n for n in zipfile.ZipFile(wheel).namelist()
+              if n.endswith(".json") and "/config/" in n
+          )
+          print(f"{wheel}: {len(shipped)} config file(s)")
+          for name in shipped:
+              print("  ", name)
+          if len(shipped) < 5:
+              sys.exit("the wheel is missing config/*.json - see doc/15 S3-18")
+          PY
+
+      - name: Install into a clean environment and build an env
+        # Deliberately run from a directory with no checkout in it, so the
+        # import resolves to the installed copy rather than the source tree.
+        run: |
+          python -m venv /tmp/clean
+          /tmp/clean/bin/pip install --upgrade pip
+          /tmp/clean/bin/pip install dist/*.whl
+          mkdir -p /tmp/elsewhere
+          cd /tmp/elsewhere
+          /tmp/clean/bin/python - <<'PY'
+          import gymnasium, gym_continuousDoubleAuction  # noqa: F401
+          from gym_continuousDoubleAuction.config_loader import config_dir
+          from gym_continuousDoubleAuction.envs.continuousDoubleAuction_env import (
+              continuousDoubleAuctionEnv,
+          )
+          print("config_dir:", config_dir())
+          env = continuousDoubleAuctionEnv({})
+          env.reset()
+          for _ in range(8):
+              env.step({a: env.action_spaces[a].sample() for a in env.agents})
+          print("stepped an installed env with", env.num_of_agents, "agents")
+          PY

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,11 @@ gym_continuousDoubleAuction/*.txt
 gym_continuousDoubleAuction/*.json
 gym_continuousDoubleAuction/visualize/json/latest_episode_data.json
 gym_continuousDoubleAuction/visualize/json/latest_episode_data.txt
+# Build artefacts. `python setup.py bdist_wheel` / `pip install .` stage into
+# build/ and drop the result in dist/; neither is source.
+build
+dist
+# Staged copy of the root config/ tree, written into the package by setup.py's
+# build_py so the wheel carries it. Generated, never edited - the canonical
+# tree is ./config/, which config_dir() finds first when running in-tree.
+gym_continuousDoubleAuction/config

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,5 @@
+# The canonical config tree lives at the repo root, outside the package.
+# setup.py's build_py stages it into gym_continuousDoubleAuction/config/ at
+# build time, but an sdist is unpacked and *then* built - so the root copy has
+# to travel in the sdist for that staging to have anything to read.
+include config/*.json

--- a/config/env_defaults.json
+++ b/config/env_defaults.json
@@ -2,10 +2,11 @@
   "_source": "gym_continuousDoubleAuction/envs/continuousDoubleAuction_env.py (__init__ and reset)",
   "_description": "Fallbacks applied when the env is constructed with a config dict that omits a key - a bare continuousDoubleAuctionEnv({}), a test fixture, or an RLlib env_config that only sets a few keys. Read through config_loader.env_default; the env holds no literal for any of them.",
   "_note": "These are STANDALONE defaults and deliberately differ from the training defaults in train_config.json: a bare env is small (num_of_agents 5, max_step 64) and renders, a training env is large and silent. Keys here use the env-side spelling: num_of_agents, not the TrainConfig field name num_agents. TrainConfig.env_config always supplies every key below, so a training run never reaches these.",
+  "_note_init_cash": "init_cash must be > 0. Trader._order_approved refuses on nav <= 0 before it inspects anything else, so a bare env built with init_cash 0 - as this file shipped until now - starts every trader bankrupt: no order is ever placed, Done_Helper.set_done puts every agent in done_set on the first pass, and terminateds['__all__'] is True after a single step(), so max_step is unreachable. It matches cli_defaults.json and train_config.json at 1,000,000 so all three agree. test_bare_env_is_tradable pins it.",
 
   "environment": {
     "num_of_agents": 5,
-    "init_cash": 0,
+    "init_cash": 1000000,
     "tick_size": 1,
     "tape_display_length": 10,
     "max_step": 64,

--- a/doc/01_overview.md
+++ b/doc/01_overview.md
@@ -116,7 +116,9 @@ other. The environment is a valid *game*; framing it as a market simulator overr
 | Truncation | at `max_step` | [`done_helper.py`](../gym_continuousDoubleAuction/envs/exchg/done_helper.py) |
 
 Note the env's **own** defaults differ from what `TrainConfig` passes — a bare
-`continuousDoubleAuctionEnv({})` gets 5 agents, `init_cash=0`, `max_step=64` and `is_render=True`.
+`continuousDoubleAuctionEnv({})` gets 5 agents, `init_cash=1,000,000`, `max_step=64` and
+`is_render=True`. (`init_cash` was `0` until it was found to make the bare env inert — every
+order refused, every agent bankrupt on step 1.)
 The full table is in [02_architecture.md](02_architecture.md) §6.
 
 Within one env step, all N agents' orders are collected, **randomly shuffled**, and then applied

--- a/doc/02_architecture.md
+++ b/doc/02_architecture.md
@@ -278,7 +278,7 @@ Passed as an `env_config` dict to `continuousDoubleAuctionEnv`
 | Key | Env default | `TrainConfig` value | Meaning |
 |---|---|---|---|
 | `num_of_agents` | 5 | 8 | Number of traders |
-| `init_cash` | 0 | 1,000,000 | Starting cash per trader |
+| `init_cash` | 1,000,000 | 1,000,000 | Starting cash per trader — must be > 0, see `env_defaults.json` |
 | `tick_size` | 1 | 1 | Book tick — **silently discarded after the first reset**, see §2.7 |
 | `tape_display_length` | 10 | 10 | Tape rows kept for display |
 | `max_step` | 64 | 4,096 | Steps before truncation |

--- a/doc/15_findings_and_recommendations.md
+++ b/doc/15_findings_and_recommendations.md
@@ -72,6 +72,33 @@ predicted outcome.
 scale the micro-penalties to reward units (S2-3), and reduce or drop the asymmetric multiplier.
 → [12 §3.3](12_perspective_rl_researcher.md#33-doing-nothing-is-a-dominant-strategy)
 
+### S1-4 · The default standalone env could not trade **[verified, fixed]**
+
+`config/env_defaults.json` shipped `init_cash: 0`. `Trader._order_approved` refuses on
+`nav <= 0` before it inspects anything else, so every trader in a bare env started bankrupt: no
+order was ever placed on any side, `Done_Helper.set_done` put all five agents in `done_set` on
+the first pass, and `terminateds["__all__"]` came back `True` after a single `step()`. The
+configured `max_step: 64` was unreachable.
+
+| `continuousDoubleAuctionEnv({})` | Before | After |
+|---|---|---|
+| Trades in 64 steps | **0** | 134 |
+| Steps before `terminateds["__all__"]` | **1** | 64 (truncated) |
+| Final NAVs | `['0','0','0','0','0']` | spread around 1,000,000 |
+
+This is the form `gymnasium.make("continuousDoubleAuction-v0")` produces and the one
+[01](01_overview.md) documents as "small, cheap and prints what it is doing". The value was
+written down in three places and its consequence in none of them.
+
+CI did not catch it: the only bare-env job is the `CDA_rand.py` smoke run, which builds its own
+env config from `cli_defaults.json` — where `init_cash` is 1,000,000 — and so overrode the one
+value that broke it.
+
+**Fixed:** `init_cash` is 1,000,000 in `env_defaults.json`, matching `cli_defaults.json` and
+`train_config.json` so all three agree. `test_env_lifecycle.py::TestBareEnvIsTradable` reads the
+checked-in file deliberately — a fixture supplying its own cash would reproduce exactly the blind
+spot the smoke run had.
+
 ---
 
 ## S2 — Major
@@ -271,15 +298,69 @@ this is disqualifying — none of the generated-LOB figures can be regenerated. 
 **Fix:** one `np.random.Generator` on the env, threaded through size sampling, initial price and
 the shuffle.
 
-### S3-6 · `install_requires` does not match the imports **[verified]**
+### S3-6 · `install_requires` does not match the imports **[verified, fixed]**
 
-`envs/` imports `ray`, `sklearn.utils`, and `six`, none of which are in `install_requires`.
+`envs/` imports `ray`, `sklearn.utils`, and `six`, none of which were in `install_requires`.
 `pip install gym_continuousDoubleAuction` without extras fails on first import. CI never catches
 it because it always installs the full `requirements.txt`.
 
-`import ray` in the env is entirely unused; `six` is a Python-2 shim replaceable by
-`io.StringIO`; `sklearn.utils.shuffle` pulls ~30 MB into every EnvRunner to shuffle ≤8 dicts —
-and is the same call that makes runs irreproducible (S3-5).
+One claim in the original entry was wrong and worth correcting, because acting on it as written
+would have left the real dependency in place: **`import ray` in the env is not entirely unused.**
+There were *two* ray imports in `continuousDoubleAuction_env.py` — a genuinely dead bare
+`import ray`, and `from ray.rllib.env.multi_agent_env import MultiAgentEnv`, which is the base
+class. A clean-venv install failed on the second, not the first.
+
+`six` is a Python-2 shim replaceable by `io.StringIO`, but it is imported from
+`envs/orderbook/`, which is off-limits to changes (see S3-4) — so it is declared rather than
+removed. `sklearn.utils.shuffle` pulls ~30 MB into every EnvRunner to shuffle ≤8 dicts, and is
+the same call that makes runs irreproducible (S3-5); it is likewise declared for now, and the
+declaration should go when the import does.
+
+**Fixed:** the dead `import ray` is gone; `ray[rllib]`, `scikit-learn` and `six` are in
+`install_requires`, which now matches what the package actually imports. The `rllib` extra keeps
+its name and carries the rest of the *training* stack (`torch`, `tensorboardX`), so
+`pip install -e ".[rllib]"` is unchanged. A second, independent packaging defect was found while
+fixing this one — see S3-18.
+
+### S3-18 · The config tree was not in the built distribution **[verified, fixed]**
+
+`setup.py` declared neither `package_data` nor `include_package_data`, and `config/` sits at the
+repo root rather than inside the package — so a wheel built from this tree carried **zero** JSON
+config files. `config_loader.config_dir()` searches `<pkg>/../config` and `<pkg>/config`; in
+`site-packages` neither exists.
+
+The failure lands at *import*, not at first use, because the config reads are default arguments
+evaluated at class-definition time in `Exchg_Helper`, `Reward_Helper`, `Action_Helper`,
+`State_Helper`, `Trader` and `Account`. Every non-editable install was therefore unusable, which
+is why the "Resolved since" entry claiming `setup.py` was fixed for non-editable installs has
+been corrected below — it fixed `find_packages()` and left this.
+
+**Fixed:** a `build_py` subclass stages `config/*.json` into `gym_continuousDoubleAuction/config/`
+at build time and `package_data` ships it — which is exactly the second location `config_dir()`
+already searched and never found. Nothing moves, no documented path changes, and the staged copy
+is git-ignored and never preferred in-tree (the repo root is checked first). `MANIFEST.in` carries
+the root tree into an sdist so the staging has something to read there too.
+
+### S3-19 · Every episode ran one step longer than `max_step` **[verified, fixed]**
+
+`Done_Helper.set_all_done` compared `self.t_step > self.max_step - 1`, but `step()` increments
+`t_step` *after* `set_step_outputs` has computed the flags. The condition first held at
+`t_step == max_step`, i.e. on the `max_step + 1`-th step, so `max_step=10` produced 11 calls to
+`step()`.
+
+The consequence is quiet rather than dramatic. `TrainConfig.train_batch_size` is defined as
+`max_step * num_episodes_per_iter`, so at the checked-in defaults the env delivered 16,388 steps
+against a declared batch of 16,384 — and the `sample_timeout_s` sizing note in
+`train_config.json` is derived from the same understated figure. Every episode length quoted in
+the documentation was off by one for the same reason.
+
+Nothing caught it because the existing loops all stop on `truncateds["__all__"]` without counting
+the steps taken to get there.
+
+**Fixed:** the test now reads `self.t_step + 1 >= self.max_step`, written in terms of *steps
+taken* rather than as a comparison against `max_step - 1`, which is what made it easy to get
+wrong. `test_env_lifecycle.py::TestEpisodeLength` pins the count at several horizons and asserts
+that truncation is reported *on* the final step rather than after it.
 
 ### S3-7 · `sys.exit()` used for error handling in the matching engine
 
@@ -442,7 +523,7 @@ Recorded so nobody re-files them. Each was a real defect at the time.
 | Per-episode pickles were unconditional | `episode_data_dir=None` / `--no-episode-data` disables them |
 | `episode_data/` was untracked noise | In `.gitignore`, both paths, with an explanatory comment |
 | **No CI** — dead `.travis.yml` | GitHub Actions, 3.11/3.12 matrix, three staged jobs |
-| `setup.py` broken for non-editable installs | `find_packages()`, real `install_requires` and extras, `__init__.py` files added |
+| `setup.py` broken for non-editable installs | ~~`find_packages()`, real `install_requires` and extras, `__init__.py` files added~~ **Premature.** That pass fixed package discovery and left two defects that still made every non-editable install fail: `install_requires` did not name `ray[rllib]`, `scikit-learn` or `six` (S3-6), and no config JSON was in the distribution at all (S3-18). Both are fixed now, and a wheel built from this tree has been installed into a clean environment and used to construct an env |
 | `observation_space`/`action_space` were plain dicts | `observation_spaces`/`action_spaces` (plural, new stack) plus per-agent getters; agent ordering stable across processes |
 | Trainable network was an 8-unit bottleneck | `fcnet_hiddens=[256,256]`, `tanh`, `vf_share_layers=False` |
 | `test_modify_order_price_change` was `@unittest.expectedFailure` | A normal passing test; the no-crossed-book invariant holds on every modification path |

--- a/doc/15_findings_and_recommendations.md
+++ b/doc/15_findings_and_recommendations.md
@@ -285,18 +285,39 @@ the *relative* tick varies **10×** across episodes — a large uncontrolled non
 partly mitigated by exposing `log_mid`. `initial_price_min/max` are read by `reset()` but omitted
 from `TrainConfig.env_config`, so training cannot narrow the range.
 
-### S3-5 · Seeding is entirely non-functional
+### S3-5 · Seeding is entirely non-functional **[verified, fixed]**
 
-`reset(seed=...)` forwards to `MultiAgentEnv.reset`, which seeds `self._np_random` — which
-nothing uses. The env draws initial price and order sizes from global `np.random`, and
-`rand_exec_seq(actions, None)` always passes `random_state=None`, so the shuffle ignores RLlib's
-`seed` too.
+`reset(seed=...)` forwarded to `MultiAgentEnv.reset`, which seeds `self._np_random` — which
+nothing read. All three of the env's random draws went to the global `np.random` instead: the
+initial price anchor in `reset`, order sizes in `Action_Helper._set_size`, and the queueing order
+in `rand_exec_seq`, whose one caller passes `seed=None` and whose
+`sklearn.utils.shuffle(..., random_state=None)` falls through to sklearn's own global
+`np.random.mtrand._rand`.
 
-**No episode is reproducible.** For a research environment whose entire output is simulated data
-this is disqualifying — none of the generated-LOB figures can be regenerated. The
-`rand_exec_seq` signature already accepts a seed; nothing passes one.
-**Fix:** one `np.random.Generator` on the env, threaded through size sampling, initial price and
-the shuffle.
+**No episode was reproducible**, which for a research environment whose entire output is
+simulated data is disqualifying — none of the generated-LOB figures could be regenerated.
+
+One correction to the original entry, because it changes how urgent this is. **Training runs
+were reproducible** — by accident rather than by design. RLlib's `EnvRunner.__init__` calls
+`update_global_seed_if_necessary`, which seeds global `random` and `np.random` from
+`config.seed + worker_index`, and that covered all three sources. Measured: with global NumPy
+seeded, two runs of the same env and actions were identical; with only `reset(seed=123)`, they
+diverged. Three caveats made it worth fixing anyway:
+
+* `run.seed` is `null` in the checked-in `train_config.json`, so nothing was seeded by default;
+* the seeding happens once per worker at construction, so episode *N* could not be reproduced
+  without replaying 1..*N*−1;
+* `restart_failed_env_runners` is on by default, and a restarted runner re-seeds from the same
+  value — rewinding its stream mid-run, so a run that loses a worker was not reproducible even
+  in principle.
+
+**Fixed:** all three sources now read `self.np_random`, gymnasium's per-env `Generator`, which
+`super().reset(seed=...)` seeds. `seed=None` deliberately does not re-seed, per the Gymnasium
+contract, so consecutive episodes still differ. `rand_exec_seq` honours its `seed` parameter —
+accepted since it was written and never used — and shuffles with `Generator.permutation`, which
+removed the `scikit-learn` dependency along with it (see S3-6). `test_seeding.py` pins this;
+its load-bearing case seeds the *global* stream to two different values and asserts the seeded
+episode is unchanged, which fails against the old code in the direction that hid the bug.
 
 ### S3-6 · `install_requires` does not match the imports **[verified, fixed]**
 
@@ -312,13 +333,16 @@ class. A clean-venv install failed on the second, not the first.
 
 `six` is a Python-2 shim replaceable by `io.StringIO`, but it is imported from
 `envs/orderbook/`, which is off-limits to changes (see S3-4) — so it is declared rather than
-removed. `sklearn.utils.shuffle` pulls ~30 MB into every EnvRunner to shuffle ≤8 dicts, and is
-the same call that makes runs irreproducible (S3-5); it is likewise declared for now, and the
-declaration should go when the import does.
+removed.
 
-**Fixed:** the dead `import ray` is gone; `ray[rllib]`, `scikit-learn` and `six` are in
-`install_requires`, which now matches what the package actually imports. The `rllib` extra keeps
-its name and carries the rest of the *training* stack (`torch`, `tensorboardX`), so
+`sklearn` is gone entirely. It pulled ~30 MB into every EnvRunner to shuffle ≤8 dicts, and was
+the same call that made runs irreproducible; `rand_exec_seq` now uses the env's own
+`Generator.permutation`, so fixing S3-5 removed the dependency rather than merely declaring it.
+
+**Fixed:** the dead `import ray` is gone; `ray[rllib]` and `six` are in `install_requires`, which
+now matches what the package actually imports, and `scikit-learn` is in neither
+`install_requires` nor `requirements.txt` because nothing imports it. The `rllib` extra keeps its
+name and carries the rest of the *training* stack (`torch`, `tensorboardX`), so
 `pip install -e ".[rllib]"` is unchanged. A second, independent packaging defect was found while
 fixing this one — see S3-18.
 
@@ -361,6 +385,39 @@ the steps taken to get there.
 taken* rather than as a comparison against `max_step - 1`, which is what made it easy to get
 wrong. `test_env_lifecycle.py::TestEpisodeLength` pins the count at several horizons and asserts
 that truncation is reported *on* the final step rather than after it.
+
+### S3-20 · The escrow-delta path for order modification was dead **[verified, fixed]**
+
+`Cash_Processor.modify_cash_transfer` computed `diff = order_val - qoute_val` and moved `diff`
+between `cash` and `cash_on_hold` — a modify treated as a pure escrow adjustment. Nothing called
+it, verified by grep across the package.
+
+It was deleted rather than wired up, because **it is only correct where the live path already
+is.** A modify is handled as cancel-and-reprocess: `cancel_cash_transfer` returns the whole old
+order value to cash, `OrderBook.modify_order` re-runs the quote through `process_limit_order`,
+and whatever is left resting is re-escrowed by `order_in_book_passive_party` — net cash movement
+`order_val - residual_val`. When the modify does not match, `residual_val == qoute_val` and the
+two are the same expression, which is why NAV conservation never told them apart:
+
+| Modify (bid 10@100) | Escrow-delta would do | Live path does |
+|---|---|---|
+| → 6@100, no match | cash **+400**, hold −400 | cash **+400**, hold −400 |
+| → 14@100, no match | cash **−400**, hold +400 | cash **−400**, hold +400 |
+| → 10@101, hits ask@101 | cash −10, hold **+10** | cash −10, hold **−394** |
+| → 10@103, hits ask@101 | cash **−30**, hold **+30** | cash **−22**, hold **−382** |
+
+Row 3 shows the escrow leg wrong by the traded value; the cash leg coincides there only because
+the fill happened *at* the quoted price, so `residual_val + trade_val == qoute_val` exactly. Row
+4 breaks that identity — the fill is 2 ticks better than quoted — and both legs are wrong.
+
+The function has no term for a fill, so it holds cash against quantity no longer in the book.
+Re-processing is not an implementation detail of modify; it is what lets a modify cross the
+spread, which this function assumes never happens.
+
+**Fixed:** deleted, with the reasoning left at the call site. The six scenarios in
+`test_modify_order.py` already constrain the behaviour — three of them cross the book and assert
+exact `cash` / `cash_on_hold` / `net_position`, which an escrow-shuffle cannot produce — and a
+seventh test now asserts the helper stays gone.
 
 ### S3-7 · `sys.exit()` used for error handling in the matching engine
 

--- a/doc/17_changelog.md
+++ b/doc/17_changelog.md
@@ -1054,3 +1054,55 @@ Three things the review had not predicted:
 * **Live state should never have been pickled.** The callback ships to every env runner and every
   checkpoint, carrying its in-flight episode tallies along. The unpickling side is a different
   process; a tally for an episode it never ran is not bookkeeping it should continue.
+
+---
+
+## 20. Three defects at the edges of a working simulator
+
+A code review of the tree at `7e6e8fb` (see [15](15_findings_and_recommendations.md) S1-4, S3-6,
+S3-18, S3-19). The finding worth recording is not any one of these individually but what they had
+in common: the parts of this codebase that are *hard* to get right — Decimal accounting, price/time
+priority, position flips, league checkpointing — were correct and defended by tests, while three of
+the parts that are *easy* to get right were broken in ways that made both documented entry points
+fail immediately. A 487-test suite exercised the env's parts thoroughly and never the shape of one
+whole default episode.
+
+### 20.1 The default env could not trade
+
+`env_defaults.json` shipped `init_cash: 0`, and `_order_approved` gates on `nav <= 0`. A bare
+`continuousDoubleAuctionEnv({})` placed no order ever and terminated after one step. Its
+`max_step: 64` had never been reachable.
+
+The reason this survived is worth more than the fix: CI's only bare-env job is the `CDA_rand.py`
+smoke run, which supplies its own `init_cash` from `cli_defaults.json` — so the one job covering
+the default env overrode the value that broke it. The new tests read the checked-in file on
+purpose, because a fixture with its own cash would rebuild the same blind spot.
+
+### 20.2 An episode ran `max_step + 1` steps
+
+`set_all_done` tested `t_step > max_step - 1` while `step()` increments `t_step` afterwards.
+`train_batch_size` is `max_step * num_episodes_per_iter`, so the env had been quietly delivering
+four more steps per iteration than the batch it was sized for. Now written as
+`t_step + 1 >= max_step` — in terms of steps taken, which is the quantity the caller counts.
+
+### 20.3 An installed package had no config and could not import
+
+Two independent defects behind one symptom, and the "Resolved since" table in
+[15](15_findings_and_recommendations.md) had already claimed `setup.py` fixed for non-editable
+installs on the strength of an earlier pass that addressed neither.
+
+`install_requires` did not name `ray[rllib]` (the env subclasses `MultiAgentEnv`), `scikit-learn`
+(`action_helper` imports `shuffle` at module scope) or `six` (`envs/orderbook/`, which is
+off-limits, and which had been resolving by accident as a transitive dependency of pandas).
+Separately, `config/` sits at the repo root outside the package with no `package_data`, so a wheel
+carried zero JSON files — and because the config reads are default arguments evaluated at
+class-definition time, that failed at *import*, not at first use.
+
+A `build_py` subclass now stages `config/*.json` into the package at build time, which is exactly
+the second location `config_dir()` already searched and never found. Nothing moved and no
+documented path changed. Verified the way it should have been all along: build a wheel, install it
+into a clean environment, construct an env.
+
+The prior entry's remediation note was also wrong in a way that would have preserved the bug —
+it said `import ray` in the env was "entirely unused". There were two ray imports, and the one
+that mattered was the base class.

--- a/doc/17_changelog.md
+++ b/doc/17_changelog.md
@@ -1106,3 +1106,51 @@ into a clean environment, construct an env.
 The prior entry's remediation note was also wrong in a way that would have preserved the bug —
 it said `import ray` in the env was "entirely unused". There were two ray imports, and the one
 that mattered was the base class.
+
+---
+
+## 21. Reproducible episodes, and one deletion
+
+Two follow-ups to §20, from the same review (see [15](15_findings_and_recommendations.md) S3-5,
+S3-6, S3-20).
+
+### 21.1 `reset(seed=...)` now seeds the episode
+
+The env had three sources of randomness — the price anchor in `reset`, order sizes in
+`_set_size`, and the queueing order in `rand_exec_seq` — and all three drew from the *global*
+`np.random`. The `seed` argument reached `gymnasium.Env`, which set `self._np_random`, which
+nothing read. All three now use `self.np_random`.
+
+Worth recording because it changes how the old behaviour should be understood: **training runs
+were already reproducible**, by accident. RLlib seeds global `random` and `np.random` per
+EnvRunner from `config.seed + worker_index`, which happened to cover all three sources. What was
+broken was reproducibility for anything that is *not* RLlib — the probes in
+[16](16_verification_log.md), the generated-LOB figures, and any test that wants to pin what a
+specific episode does rather than an invariant that holds for every episode. That last absence
+is visible in the shape of the suite: it tests conservation and structure, and had nothing
+pinning a trajectory.
+
+Three things also made the accidental version unreliable: `run.seed` is `null` by default, the
+seeding happens once per worker rather than per episode, and a runner restarted by
+`restart_failed_env_runners` re-seeds from the same value and rewinds its stream mid-run.
+
+`rand_exec_seq` had accepted a `seed` parameter since it was written that nothing ever passed.
+It is honoured now, and the shuffle is `Generator.permutation` rather than
+`sklearn.utils.shuffle` — so `scikit-learn`, a ~30 MB dependency in every EnvRunner used to
+reorder at most `num_agents` dicts, is out of the requirements entirely. Fixing the seeding and
+removing the dependency turned out to be the same edit.
+
+### 21.2 `modify_cash_transfer` deleted
+
+The one function in the accounting layer that computed the escrow delta of a size change
+directly, with no call sites. It is gone rather than wired up because it is only correct where
+the live cancel-and-reprocess path already is: when a modify does not match, the two are
+algebraically the same expression, which is why NAV conservation never distinguished them. When
+a modify *does* match — which `modify_order` fully supports, since it re-runs the quote through
+`process_limit_order` — the escrow-delta form has no term for the fill and holds cash against
+quantity that is no longer resting. Measured divergence and the full table are in
+[15](15_findings_and_recommendations.md) S3-20.
+
+The lesson is the one §20 opened with. This is the third piece of code found in this review that
+was plausible, documented, and unreachable; a reader extending modify handling would reasonably
+have changed it and seen no effect.

--- a/doc/18_configuration.md
+++ b/doc/18_configuration.md
@@ -106,7 +106,7 @@ bare `continuousDoubleAuctionEnv({})` — a test fixture, a notebook, an `env_co
 hand — falls back to `env_defaults.json`.
 
 Those standalone values deliberately differ from the training ones: `num_of_agents=5`,
-`max_step=64`, `init_cash=0`, `is_render=true`. A bare env is small, cheap and prints what it is
+`max_step=64`, `init_cash=1000000`, `is_render=true`. A bare env is small, cheap and prints what it is
 doing; a training env is large and silent. Keeping them in a separate file is what lets both be
 explicit instead of one being a literal buried in `__init__`.
 

--- a/gym_continuousDoubleAuction/envs/account/cash_processor.py
+++ b/gym_continuousDoubleAuction/envs/account/cash_processor.py
@@ -61,35 +61,26 @@ class Cash_Processor(object):
         self.cash += trade_val
         return 0
 
-    def modify_cash_transfer(self, qoute, order):
-        """
-        Update account of trader accordingly if his orders in LOB changes.
-
-        note:
-            Changes in LOB orders refer to changes in size.
-            If size decrease, deduct from cash_on_hold, return to cash.
-            If size increase, deduct from cash, add to cash_on_hold.
-        """
-
-        order_val = (order.price) * (order.quantity)
-
-
-
-        qoute_val = Decimal(str(qoute['price'])) * qoute['quantity']
-        
-        
-        
-        if order_val >= qoute_val: # reducing size
-            diff = order_val - qoute_val
-            # deduct from cash_on_hold, return to cash
-            self.cash_on_hold -= diff
-            self.cash += diff
-        else: # order_val < qoute_val, increasing size
-            diff = qoute_val - order_val
-            # deduct from cash, add to cash_on_hold
-            self.cash -= diff
-            self.cash_on_hold += diff
-        return 0
+    # `modify_cash_transfer` used to sit here: it moved
+    # `order_val - qoute_val` between cash and cash_on_hold, as the escrow
+    # delta of a size change. Nothing called it, and it is deleted rather than
+    # wired up because it is only correct where the live path already is.
+    #
+    # A modify is handled as cancel-and-reprocess: `cancel_cash_transfer`
+    # returns the whole old order value to cash, `OrderBook.modify_order`
+    # re-runs the quote through `process_limit_order`, and whatever is left
+    # resting is re-escrowed by `order_in_book_passive_party`. Net cash movement
+    # is `order_val - residual_val`. When the modify does not match,
+    # `residual_val == qoute_val` and the two are the same expression - which is
+    # why NAV conservation never distinguished them.
+    #
+    # When it *does* match they diverge, and the deleted function is the wrong
+    # one: it has no term for a fill, so it escrows cash against quantity that
+    # is no longer resting. Modifying a bid of 10@100 to 10@101 into a resting
+    # ask at 101 moves cash_on_hold by -394 on the live path and would have
+    # moved it by +10 here. Re-processing is not an implementation detail of
+    # modify - it is what lets a modify cross the spread, which this function
+    # assumes never happens. See doc/15 S3-20.
 
     def cancel_cash_transfer(self, order):
         """

--- a/gym_continuousDoubleAuction/envs/continuousDoubleAuction_env.py
+++ b/gym_continuousDoubleAuction/envs/continuousDoubleAuction_env.py
@@ -173,7 +173,19 @@ class continuousDoubleAuctionEnv(
                 
     # Updated reset method to return proper format for new API
     def reset(self, *, seed=None, options=None):
-        # Call parent reset if it exists
+        # Call parent reset if it exists.
+        #
+        # This is what seeds `self.np_random`, gymnasium's per-env Generator,
+        # and it is the only thing the `seed` argument does. It used to do
+        # nothing observable, because every random draw in the env went to the
+        # global `np.random` instead: the price anchor here, order sizes in
+        # `_set_size`, and the queueing order in `rand_exec_seq`. All three now
+        # read `self.np_random`, so `reset(seed=...)` means what the Gymnasium
+        # API says it means (doc/15 S3-5).
+        #
+        # `seed=None` deliberately does not re-seed - the contract is that an
+        # env which already has a generator keeps its stream across resets, so
+        # consecutive episodes differ.
         if hasattr(super(), 'reset'):
             super().reset(seed=seed)
 
@@ -203,10 +215,10 @@ class continuousDoubleAuctionEnv(
 
         self.t_step = 0
 
-        # Establish initial price anchor
+        # Establish initial price anchor, from the seeded generator.
         low = self._cfg("initial_price_min")
         high = self._cfg("initial_price_max")
-        self.last_price = float(np.random.randint(low, high + 1))
+        self.last_price = float(self.np_random.integers(low, high + 1))
 
         self.reset_traders_acc()
 

--- a/gym_continuousDoubleAuction/envs/continuousDoubleAuction_env.py
+++ b/gym_continuousDoubleAuction/envs/continuousDoubleAuction_env.py
@@ -5,7 +5,6 @@ import pandas as pd
 
 import gymnasium as gym
 
-import ray
 from ray.rllib.env.multi_agent_env import MultiAgentEnv
 
 from .orderbook.orderbook import OrderBook

--- a/gym_continuousDoubleAuction/envs/exchg/action_helper.py
+++ b/gym_continuousDoubleAuction/envs/exchg/action_helper.py
@@ -2,7 +2,6 @@ import numpy as np
 import random
 
 from gymnasium import spaces
-from sklearn.utils import shuffle
 
 from ...config_loader import constant, constants, env_default
 from .state_helper import BOOK_ROW_ORDER
@@ -172,15 +171,32 @@ class Action_Helper():
 
         return acts
 
-    def rand_exec_seq(self, actions, seed):
+    def rand_exec_seq(self, actions, seed=None):
         """
         Shuffle actions execution sequence.
 
+        Which agent's order reaches the book first inside a step is the one
+        piece of the env's randomness that decides who gets a fill, so it has
+        to come from the seeded stream like the rest of it.
+
+        This was `sklearn.utils.shuffle(actions, random_state=seed)` with the
+        one caller passing `seed=None`, which falls through to sklearn's global
+        `np.random.mtrand._rand` - so the queueing order ignored the seed
+        entirely (doc/15 S3-5), and shuffling at most `num_agents` dicts cost a
+        ~30MB dependency in every EnvRunner (S3-6).
+
         Arguments:
             actions: A list of actions acceptable by the LOB.
+            seed: Pins this one shuffle, for a caller that wants a fixed order
+                  without touching the env's stream. `None` - what `step` passes
+                  - draws from the env RNG, which `reset(seed=...)` seeds.
+
+        Returns:
+            A new list; the argument is not reordered in place, as before.
         """
 
-        return shuffle(actions, random_state=seed) # seed for reproducible behavior
+        rng = np.random.default_rng(seed) if seed is not None else self.np_random
+        return [actions[i] for i in rng.permutation(len(actions))]
 
     def do_actions(self, actions):
         """
@@ -306,10 +322,15 @@ class Action_Helper():
         Returns:
             A size sampled from the distribution.
         """
+        # self.np_random, not the global np.random: this is gymnasium's own
+        # per-env Generator, seeded by `reset(seed=...)`. Drawing from the
+        # global stream is what made episodes irreproducible (doc/15 S3-5) -
+        # order size is sampled every step for every agent, so it is the
+        # heaviest consumer of randomness in the env.
         if type == 'market':
-            sample = np.random.normal(mkt_size_mean_mul * mean, sigma, 1)
+            sample = self.np_random.normal(mkt_size_mean_mul * mean, sigma, 1)
         else:
-            sample = np.random.normal(limit_size_mean_mul * mean, sigma, 1)
+            sample = self.np_random.normal(limit_size_mean_mul * mean, sigma, 1)
 
         # return np.asscalar(np.rint(np.abs(sample)))
         # int(): np.rint already rounds to a whole number, but .item() hands

--- a/gym_continuousDoubleAuction/envs/exchg/done_helper.py
+++ b/gym_continuousDoubleAuction/envs/exchg/done_helper.py
@@ -34,9 +34,18 @@ class Done_Helper(object):
 
         # Check if all traders are done
         all_agents_done = len(self.done_set) == len(self.traders)
-        
-        # Check if max step has been reached
-        episode_timed_out = self.t_step > self.max_step - 1
+
+        # Check if max step has been reached.
+        #
+        # `t_step` is the 0-based index of the step being completed right now:
+        # `step()` increments it *after* this runs, so the number of steps the
+        # episode has taken is `t_step + 1`. Written that way rather than as a
+        # comparison against `max_step - 1`, which is what made this off by one
+        # - `t_step > max_step - 1` first held at `t_step == max_step`, i.e. on
+        # the (max_step + 1)-th step, so every episode ran one step long and
+        # TrainConfig.train_batch_size (`max_step * num_episodes_per_iter`)
+        # understated the batch by one step per episode.
+        episode_timed_out = self.t_step + 1 >= self.max_step
 
         # Set "__all__" to 1 if either condition is met
         # terminateds["__all__"] = 1 if all_agents_done or episode_timed_out else 0

--- a/gym_continuousDoubleAuction/test/test_env_lifecycle.py
+++ b/gym_continuousDoubleAuction/test/test_env_lifecycle.py
@@ -1,0 +1,122 @@
+"""The bare env has to be a working env, and an episode has to be `max_step` long.
+
+Two defects that survived a 487-test suite because nothing asserted the thing
+each is about - the suite exercised the env's *parts* thoroughly and never the
+shape of a whole default episode.
+
+**R1.** `config/env_defaults.json` shipped `init_cash: 0`, and
+`Trader._order_approved` refuses on `nav <= 0` before it inspects anything
+else. So `continuousDoubleAuctionEnv({})` - the form `gymnasium.make(
+"continuousDoubleAuction-v0")` produces and the one doc/01 documents - placed
+no order ever, put every agent in `done_set` on the first pass, and reported
+`terminateds["__all__"]` after a single step. CI missed it because its only
+bare-env job is `CDA_rand.py`, which supplies its own `init_cash` from
+`cli_defaults.json` and so overrides the value that breaks it. These tests read
+the checked-in file deliberately: a fixture supplying its own cash would
+reproduce exactly the blind spot.
+
+**R3.** `set_all_done` compared `t_step > max_step - 1`, but `step()` increments
+`t_step` *after* the flags are computed, so truncation arrived one step late and
+every episode ran `max_step + 1` steps. Nothing caught it because the existing
+loops all stop on `truncateds["__all__"]` without counting. `train_batch_size`
+is defined as `max_step * num_episodes_per_iter`, so the count is the contract.
+"""
+import pytest
+
+from gym_continuousDoubleAuction.config_loader import env_default
+from gym_continuousDoubleAuction.envs.continuousDoubleAuction_env import (
+    continuousDoubleAuctionEnv,
+)
+
+#: Enough for a random policy to cross the spread repeatedly at the default
+#: five agents; small enough to stay a unit test.
+_TRADE_PROBE_STEPS = 64
+
+
+def _run(env, limit):
+    """Step `env` with sampled actions until it ends. Returns (steps, trades)."""
+    steps = trades = 0
+    while steps < limit:
+        _obs, _rew, terminateds, truncateds, infos = env.step(
+            {a: env.action_spaces[a].sample() for a in env.agents}
+        )
+        steps += 1
+        trades += sum(i["num_trades_step"] for i in infos.values())
+        if terminateds.get("__all__") or truncateds.get("__all__"):
+            break
+    return steps, trades
+
+
+class TestBareEnvIsTradable:
+    """`continuousDoubleAuctionEnv({})` against the checked-in defaults."""
+
+    def test_default_init_cash_is_positive(self):
+        """The precondition every other behaviour here rests on.
+
+        Asserted separately from the behaviour so a regression names its own
+        cause: `_order_approved` gates on NAV, so a zero here disables the
+        entire order path and the failures below would all be downstream noise.
+        """
+        assert env_default("init_cash") > 0
+
+    def test_bare_env_trades(self):
+        env = continuousDoubleAuctionEnv({})
+        env.reset()
+        _steps, trades = _run(env, _TRADE_PROBE_STEPS)
+        assert trades > 0, (
+            "the default env placed no trades - every order was refused, which "
+            "is what init_cash <= 0 does via Trader._order_approved"
+        )
+
+    def test_bare_env_survives_its_first_step(self):
+        """The symptom that made the old default unusable, pinned directly."""
+        env = continuousDoubleAuctionEnv({})
+        env.reset()
+        _obs, _rew, terminateds, truncateds, _infos = env.step(
+            {a: env.action_spaces[a].sample() for a in env.agents}
+        )
+        assert not terminateds["__all__"]
+        assert not truncateds["__all__"]
+        assert env.done_set == set(), (
+            f"agents went bankrupt on step 1: {sorted(env.done_set)}"
+        )
+
+    def test_bare_env_runs_to_its_configured_horizon(self):
+        env = continuousDoubleAuctionEnv({})
+        env.reset()
+        steps, _trades = _run(env, env.max_step + 5)
+        assert steps == env.max_step
+
+
+class TestEpisodeLength:
+    """An episode is exactly `max_step` calls to `step()`."""
+
+    @pytest.mark.parametrize("max_step", [1, 2, 5, 10, 64])
+    def test_truncation_lands_on_max_step(self, max_step):
+        env = continuousDoubleAuctionEnv({
+            "max_step": max_step, "num_of_agents": 3, "is_render": False,
+        })
+        env.reset()
+        steps, _trades = _run(env, max_step + 5)
+        assert steps == max_step
+
+    def test_the_last_step_is_the_truncated_one(self, ):
+        """Truncation is reported *on* the final step, not after it.
+
+        The distinction the off-by-one turned on: a caller that stops when
+        `truncateds["__all__"]` is set must have taken `max_step` steps at that
+        point, not `max_step + 1`.
+        """
+        max_step = 8
+        env = continuousDoubleAuctionEnv({
+            "max_step": max_step, "num_of_agents": 3, "is_render": False,
+        })
+        env.reset()
+        for step in range(1, max_step + 1):
+            _obs, _rew, _term, truncateds, _infos = env.step(
+                {a: env.action_spaces[a].sample() for a in env.agents}
+            )
+            assert truncateds["__all__"] is (step == max_step), (
+                f"step {step} of {max_step} reported "
+                f"truncateds['__all__']={truncateds['__all__']}"
+            )

--- a/gym_continuousDoubleAuction/test/test_modify_order.py
+++ b/gym_continuousDoubleAuction/test/test_modify_order.py
@@ -84,3 +84,33 @@ class TestModifyOrderAccounting:
         assert self.trader_b.acc.cash == Decimal('9500')
         assert self.trader_b.acc.cash_on_hold == Decimal('0')
         assert self.trader_b.acc.net_position == Decimal('5')
+
+
+class TestModifyIsCancelAndReprocess:
+    """The escrow-shuffle implementation of modify must not come back.
+
+    `Cash_Processor.modify_cash_transfer` moved `order_val - qoute_val` between
+    cash and cash_on_hold - a pure escrow adjustment. It was never called, and
+    was deleted rather than wired up because it is only correct where the live
+    path already is: when the modify does not match, the residual left resting
+    equals the whole new quote, so `cancel_cash_transfer` plus re-escrow comes
+    to the same number. When the modify *does* match they diverge, and the
+    escrow-shuffle is the wrong one - it has no term for a fill, so it holds
+    cash against quantity that is no longer in the book.
+
+    Scenarios 1, 5 and 6 above are what actually constrain this: each crosses
+    the book and asserts exact cash, cash_on_hold and net_position afterwards,
+    which an escrow-shuffle cannot produce. This test only stops the function
+    being reintroduced alongside them. See doc/15 S3-20.
+    """
+
+    def test_the_escrow_shuffle_helper_is_gone(self):
+        from gym_continuousDoubleAuction.envs.account.cash_processor import (
+            Cash_Processor,
+        )
+
+        assert not hasattr(Cash_Processor, "modify_cash_transfer"), (
+            "modify_cash_transfer is back. A modify is handled as "
+            "cancel-and-reprocess so that it can cross the spread; an escrow "
+            "delta cannot express a fill. See the six scenarios above."
+        )

--- a/gym_continuousDoubleAuction/test/test_seeding.py
+++ b/gym_continuousDoubleAuction/test/test_seeding.py
@@ -1,0 +1,194 @@
+"""`reset(seed=...)` has to actually seed the episode.
+
+doc/15 S3-5. The env drew from three separate sources of randomness and every
+one of them went to the *global* `np.random`: the price anchor in `reset`,
+order sizes in `Action_Helper._set_size`, and the queueing order in
+`rand_exec_seq`, which called `sklearn.utils.shuffle(actions, random_state=None)`
+- sklearn's `None` meaning its own global `np.random.mtrand._rand`. So
+`reset(seed=...)` forwarded the seed to `gymnasium.Env`, which set
+`self._np_random`, which nothing read. Two episodes with the same seed and the
+same actions diverged.
+
+Training runs were reproducible anyway, by accident rather than by design:
+RLlib's `EnvRunner.__init__` calls `update_global_seed_if_necessary`, which
+seeds global `random` and `np.random` from `config.seed + worker_index`. That
+covered all three sources - but only once per worker (so episode N cannot be
+reproduced without replaying 1..N-1), only if `run.seed` is set (it is `null`
+in the checked-in config), and only until a restarted env runner re-seeds from
+the same value and rewinds its stream mid-run.
+
+These tests deliberately do not touch global `np.random`. That is the point: if
+they passed only because something seeded the global stream, they would pass
+just as well against the code this is fixing.
+"""
+import numpy as np
+import pytest
+
+from gym_continuousDoubleAuction.envs.continuousDoubleAuction_env import (
+    continuousDoubleAuctionEnv,
+)
+
+ENV_CONFIG = {
+    "num_of_agents": 4,
+    "init_cash": 1000000,
+    "max_step": 120,
+    "is_render": False,
+}
+
+#: Long enough that all three randomness sources have been drawn from many
+#: times, and that a book has formed and traded.
+_STEPS = 120
+
+
+def _trajectory(seed, action_seed=7, steps=_STEPS):
+    """Run an episode under `seed`, holding the *actions* fixed across runs.
+
+    The actions come from a `RandomState` local to this call, so the only thing
+    that can differ between two trajectories is the env's own randomness -
+    which is exactly what `seed` is supposed to pin.
+    """
+    env = continuousDoubleAuctionEnv(dict(ENV_CONFIG))
+    env.reset(seed=seed)
+
+    action_rng = np.random.RandomState(action_seed)
+    record = []
+    for _ in range(steps):
+        actions = {}
+        for agent_id in env.agents:
+            space = env.action_spaces[agent_id]
+            space.seed(int(action_rng.randint(0, 2**31 - 1)))
+            actions[agent_id] = space.sample()
+        _obs, rewards, _term, _trunc, infos = env.step(actions)
+        record.append((
+            env.last_price,
+            tuple(round(float(r), 9) for r in rewards.values()),
+            tuple(infos[a]["NAV"] for a in env.agents),
+            tuple(infos[a]["net_position"] for a in env.agents),
+        ))
+    return record
+
+
+class TestResetSeedIsHonoured:
+
+    def test_same_seed_gives_the_same_episode(self):
+        assert _trajectory(seed=123) == _trajectory(seed=123)
+
+    def test_different_seeds_give_different_episodes(self):
+        """Otherwise the test above would pass on an env with no randomness."""
+        assert _trajectory(seed=123) != _trajectory(seed=456)
+
+    def test_the_price_anchor_is_seeded(self):
+        """The one draw that happens in `reset` itself, before any step."""
+        anchors = []
+        for _ in range(2):
+            env = continuousDoubleAuctionEnv(dict(ENV_CONFIG))
+            env.reset(seed=2024)
+            anchors.append(env.last_price)
+        assert anchors[0] == anchors[1]
+
+    def test_seed_none_does_not_reset_the_stream(self):
+        """The Gymnasium contract: an env that has a generator keeps it.
+
+        Consecutive episodes of one env must differ, or every episode of a
+        training run would be a replay of the first.
+        """
+        env = continuousDoubleAuctionEnv(dict(ENV_CONFIG))
+        env.reset(seed=99)
+        first = env.last_price
+        anchors = set()
+        for _ in range(12):
+            env.reset()
+            anchors.add(env.last_price)
+        assert len(anchors) > 1, (
+            f"12 unseeded resets all produced last_price={first}; the stream "
+            f"is being re-seeded when it should be continuing"
+        )
+
+    def test_global_numpy_is_not_the_source(self):
+        """Seeding the global stream must not change a seeded episode.
+
+        This is the regression that matters. Before the fix the env read global
+        `np.random`, so this assertion fails - and it fails in the direction
+        that hides the bug, because a globally seeded process looks perfectly
+        reproducible.
+        """
+        np.random.seed(1)
+        under_one_global_seed = _trajectory(seed=321)
+        np.random.seed(2)
+        under_another = _trajectory(seed=321)
+        assert under_one_global_seed == under_another
+
+
+class TestExecutionOrderIsSeeded:
+    """`rand_exec_seq` decides who reaches the book first, so who gets filled."""
+
+    def _orders(self, seed, calls=40):
+        env = continuousDoubleAuctionEnv(dict(ENV_CONFIG))
+        env.reset(seed=seed)
+        actions = [{"ID": f"agent_{i}"} for i in range(8)]
+        return [
+            tuple(a["ID"] for a in env.rand_exec_seq(list(actions), None))
+            for _ in range(calls)
+        ]
+
+    def test_shuffle_follows_the_env_seed(self):
+        assert self._orders(seed=5) == self._orders(seed=5)
+
+    def test_shuffle_actually_shuffles(self):
+        orders = self._orders(seed=5)
+        assert len(set(orders)) > 1, "the queueing order never changed"
+
+    def test_shuffle_is_a_permutation(self):
+        expected = {f"agent_{i}" for i in range(8)}
+        for order in self._orders(seed=5, calls=10):
+            assert set(order) == expected
+            assert len(order) == len(expected)
+
+    def test_explicit_seed_pins_one_shuffle(self):
+        """The `seed` parameter, which had been accepted and never honoured."""
+        env = continuousDoubleAuctionEnv(dict(ENV_CONFIG))
+        env.reset(seed=1)
+        actions = [{"ID": f"agent_{i}"} for i in range(8)]
+        first = env.rand_exec_seq(list(actions), 42)
+        second = env.rand_exec_seq(list(actions), 42)
+        assert [a["ID"] for a in first] == [a["ID"] for a in second]
+
+    def test_shuffle_does_not_reorder_in_place(self):
+        """`sklearn.utils.shuffle` returned a new list; so must this."""
+        env = continuousDoubleAuctionEnv(dict(ENV_CONFIG))
+        env.reset(seed=1)
+        actions = [{"ID": f"agent_{i}"} for i in range(8)]
+        before = list(actions)
+        env.rand_exec_seq(actions, None)
+        assert actions == before
+
+
+class TestSklearnIsGone:
+
+    def test_the_env_package_does_not_import_sklearn(self):
+        """A ~30MB dependency in every EnvRunner, to shuffle <= num_agents dicts.
+
+        Checked by parsing each module's import statements rather than by
+        catching ImportError, because sklearn is installed here - the claim is
+        that the env no longer reaches for it, not that it is unavailable. And
+        by AST rather than by grepping the text, because the comment recording
+        why the call was removed names it too.
+        """
+        import ast
+        from pathlib import Path
+
+        import gym_continuousDoubleAuction.envs as envs_pkg
+
+        offenders = []
+        for path in Path(envs_pkg.__file__).parent.rglob("*.py"):
+            for node in ast.walk(ast.parse(path.read_text())):
+                if isinstance(node, ast.Import):
+                    names = [alias.name for alias in node.names]
+                elif isinstance(node, ast.ImportFrom):
+                    names = [node.module or ""]
+                else:
+                    continue
+                if any(n.split(".")[0] == "sklearn" for n in names):
+                    offenders.append(f"{path.name}:{node.lineno}")
+
+        assert not offenders, f"sklearn imported at {offenders}"

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,7 +33,6 @@ torch>=2.13.0,<3
 numpy>=2.2,<3
 pandas>=3.0,<4
 scipy>=1.18,<2
-scikit-learn>=1.9,<2
 
 # --- Env internals ------------------------------------------------------------
 sortedcontainers>=2.4      # order book price-level trees

--- a/setup.py
+++ b/setup.py
@@ -17,8 +17,64 @@ after installing you can do either of:
 
 For RLlib the second form is what you want, registered via tune.register_env -
 see gym_continuousDoubleAuction/train/train.py.
+
+------------------------------------------------------------------------------
+The config tree ships inside the wheel
+------------------------------------------------------------------------------
+`config/` is checked in at the repo root, which is where `config_loader.
+config_dir()` looks first and where every doc path points. That location is not
+inside the package, so it was not in the built distribution at all: a wheel
+built from this tree carried zero JSON files, and because the config reads are
+default arguments evaluated at class-definition time (`Exchg_Helper`,
+`Reward_Helper`, `Action_Helper`, `State_Helper`, `Trader`, `Account`), an
+installed copy raised `FileNotFoundError` on *import* rather than on use.
+
+`_BuildPyWithConfig` stages the root `config/*.json` into
+`gym_continuousDoubleAuction/config/` at build time, and `package_data` puts it
+in the distribution - which is exactly the second location `config_dir()`
+already searched and never found. Nothing moves and no path in the docs
+changes. The staged copy is a build artefact, is git-ignored, and is never
+preferred in-tree because `config_dir()` checks the repo root first.
 """
+import os
+import shutil
+
 from setuptools import setup, find_packages
+from setuptools.command.build_py import build_py as _build_py
+
+_HERE = os.path.abspath(os.path.dirname(__file__))
+_PACKAGE = "gym_continuousDoubleAuction"
+
+#: Canonical config tree (repo root) and the in-package copy built from it.
+_CONFIG_SRC = os.path.join(_HERE, "config")
+_CONFIG_DST = os.path.join(_HERE, _PACKAGE, "config")
+
+
+def _stage_config():
+    """Copy `config/*.json` into the package so the build can include it.
+
+    Rebuilt from scratch each time rather than updated in place, so a file
+    deleted from the canonical tree cannot survive in the staged one and end up
+    shipped. Silently does nothing when the source is absent, which is the case
+    when building from an unpacked sdist that already carries the staged copy.
+    """
+    if not os.path.isdir(_CONFIG_SRC):
+        return
+    shutil.rmtree(_CONFIG_DST, ignore_errors=True)
+    os.makedirs(_CONFIG_DST, exist_ok=True)
+    for name in os.listdir(_CONFIG_SRC):
+        if name.endswith(".json"):
+            shutil.copy2(os.path.join(_CONFIG_SRC, name),
+                         os.path.join(_CONFIG_DST, name))
+
+
+class _BuildPyWithConfig(_build_py):
+    """`build_py`, with the config tree staged into the package first."""
+
+    def run(self):
+        _stage_config()
+        super().run()
+
 
 setup(
     name="gym_continuousDoubleAuction",
@@ -28,14 +84,21 @@ setup(
         "for reinforcement learning, with RLlib league-based self-play."
     ),
     packages=find_packages(exclude=["*test", "*test.*", "test.*", "test"]),
+    package_data={_PACKAGE: ["config/*.json"]},
+    cmdclass={"build_py": _BuildPyWithConfig},
     # Only 3.12 is CI-tested (see .github/workflows/tests.yml). >=3.10 is not
     # claimed: numpy stopped shipping 3.10/3.11 wheels partway through its 2.x
     # series, which is exactly what broke the old 3.11 CI job.
     python_requires=">=3.12",
     install_requires=[
-        # Kept deliberately narrow: these are what the *environment* needs to
-        # import. The RL training stack (ray[rllib], torch) lives in
-        # requirements.txt so the env stays usable without it.
+        # What `import gym_continuousDoubleAuction.envs` actually needs. This
+        # list used to be "deliberately narrow" on the stated reasoning that
+        # the env stays usable without the RL stack - which was not true of the
+        # code: `continuousDoubleAuction_env` subclasses `MultiAgentEnv`, so
+        # ray[rllib] is a hard import, and `action_helper` imports
+        # `sklearn.utils.shuffle` at module scope. Both were reachable only via
+        # extras, so `pip install gym_continuousDoubleAuction` produced a
+        # package that could not be imported. The list now matches the imports.
         "gymnasium==1.2.2",
         # See requirements.txt for why the floor is 2.2, not 2.5: numpy has no
         # 3.10 wheels from 2.3.0 onward, and no 3.11 wheels from 2.5.0 onward.
@@ -43,15 +106,34 @@ setup(
         "pandas>=3.0,<4",
         "sortedcontainers>=2.4",
         "tabulate>=0.10",
+        # Base class of the env. Pinned to the same release requirements.txt
+        # pins, because Ray 2.56.x hard-pins gymnasium==1.2.2 and the two
+        # cannot be bumped independently.
+        "ray[rllib]==2.56.1",
+        # `Action_Helper.rand_exec_seq` only. A ~30MB dependency to shuffle at
+        # most `num_agents` dicts, and the same call that makes runs
+        # irreproducible - see doc/15 S3-5/S3-6, where replacing it with
+        # `random.Random(seed).shuffle` is the recommended fix. Declared here
+        # because it is imported today; drop the declaration with the import.
+        "scikit-learn>=1.9,<2",
+        # `six.moves.cStringIO` in envs/orderbook/{orderbook,orderlist}.py.
+        # A Python-2 shim that `io.StringIO` replaces, but envs/orderbook/ is
+        # off-limits to changes (doc/15 S3-4), so the dependency is declared
+        # rather than removed. It had been resolving only by accident, as a
+        # transitive dependency of pandas.
+        "six>=1.16",
     ],
     extras_require={
         # pip install -e ".[rllib]"
+        #
+        # ray[rllib] moved to install_requires above; this keeps its name and
+        # stays valid to install, and now carries the rest of the *training*
+        # stack - what train/ needs beyond what the env needs.
         "rllib": [
-            "ray[rllib]==2.56.1",
             "torch>=2.13.0,<3",
             "tensorboardX>=2.6.5",
         ],
-        "plot": ["matplotlib>=3.11,<4", "scikit-learn>=1.9,<2", "scipy>=1.18,<2"],
+        "plot": ["matplotlib>=3.11,<4", "scipy>=1.18,<2"],
         "dev": ["pytest>=8"],
     },
 )

--- a/setup.py
+++ b/setup.py
@@ -95,10 +95,9 @@ setup(
         # list used to be "deliberately narrow" on the stated reasoning that
         # the env stays usable without the RL stack - which was not true of the
         # code: `continuousDoubleAuction_env` subclasses `MultiAgentEnv`, so
-        # ray[rllib] is a hard import, and `action_helper` imports
-        # `sklearn.utils.shuffle` at module scope. Both were reachable only via
-        # extras, so `pip install gym_continuousDoubleAuction` produced a
-        # package that could not be imported. The list now matches the imports.
+        # ray[rllib] is a hard import. It was reachable only via an extra, so
+        # `pip install gym_continuousDoubleAuction` produced a package that
+        # could not be imported. The list now matches the imports.
         "gymnasium==1.2.2",
         # See requirements.txt for why the floor is 2.2, not 2.5: numpy has no
         # 3.10 wheels from 2.3.0 onward, and no 3.11 wheels from 2.5.0 onward.
@@ -110,12 +109,6 @@ setup(
         # pins, because Ray 2.56.x hard-pins gymnasium==1.2.2 and the two
         # cannot be bumped independently.
         "ray[rllib]==2.56.1",
-        # `Action_Helper.rand_exec_seq` only. A ~30MB dependency to shuffle at
-        # most `num_agents` dicts, and the same call that makes runs
-        # irreproducible - see doc/15 S3-5/S3-6, where replacing it with
-        # `random.Random(seed).shuffle` is the recommended fix. Declared here
-        # because it is imported today; drop the declaration with the import.
-        "scikit-learn>=1.9,<2",
         # `six.moves.cStringIO` in envs/orderbook/{orderbook,orderlist}.py.
         # A Python-2 shim that `io.StringIO` replaces, but envs/orderbook/ is
         # off-limits to changes (doc/15 S3-4), so the dependency is declared


### PR DESCRIPTION
Five fixes from an independent code review of `7e6e8fb`, plus the CI job that would have caught two of them. `doc/15_findings_and_recommendations.md` is already unusually thorough, so this covers what was **absent** from it (S1-4, S3-18, S3-19, S3-20) and two entries it already tracked (S3-5, S3-6).

## The shape of what was wrong

The parts of this codebase that are *hard* to get right are correct and defended by tests. Stress-testing found no fault in any of them:

- **NAV conservation is exact.** 4,000 random steps, 8 agents — the ledger sums to `Decimal('8000000.000…')` against 8 × 1,000,000. Equality, not tolerance.
- **Order-book invariants hold.** 3,000 steps, 6 agents, checked every step on both sides: `tree.volume == Σ level volumes == Σ order_map quantities`, `num_orders == len(order_map)`, `depth == len(price_map)`, never crossed. Zero violations across the partial-fill, exact-fill, walk-the-book, self-match and modify-reprocess paths.
- **No solvency escapes.** Minimum cash 486,068, minimum NAV 981,245, against positions reaching ±3,543 contracts.

Three of the parts that are *easy* to get right were broken in ways that made both documented entry points fail immediately. A 487-test suite exercised the env's parts thoroughly and never the shape of one whole default episode.

## Fixes

### S1-4 — the default env terminated after one step

`env_defaults.json` shipped `init_cash: 0`, and `Trader._order_approved` refuses on `nav <= 0` before it inspects anything else. A bare `continuousDoubleAuctionEnv({})` — what `gymnasium.make("continuousDoubleAuction-v0")` produces, and what `doc/01` describes as "small, cheap and prints what it is doing" — placed no order ever, put every agent in `done_set` on the first pass, and terminated after a single `step()`. Its configured `max_step: 64` had never been reachable.

| `continuousDoubleAuctionEnv({})` | Before | After |
|---|---|---|
| Trades in 64 steps | **0** | 134 |
| Steps before `terminateds["__all__"]` | **1** | 64 (truncated) |
| Final NAVs | `['0','0','0','0','0']` | spread around 1,000,000 |

Why it survived matters more than the fix: CI's only bare-env job is the `CDA_rand.py` smoke run, which supplies its own `init_cash` from `cli_defaults.json` — so the one job covering the default env overrode the value that broke it. The new tests read the checked-in file on purpose; a fixture with its own cash would rebuild the same blind spot.

### S3-19 — every episode ran `max_step + 1` steps

`set_all_done` compared `t_step > max_step - 1` while `step()` increments `t_step` afterwards, so truncation arrived one step late. `train_batch_size` is `max_step * num_episodes_per_iter`, so the env had been quietly delivering four more steps per iteration than the batch it was sized for, and the `sample_timeout_s` sizing note in `train_config.json` is derived from the understated figure.

Now `t_step + 1 >= max_step` — expressed in *steps taken*, which is the quantity the caller counts, and the framing whose absence made this easy to get wrong. Verified at `max_step` ∈ {1, 2, 5, 10, 64}: each yields exactly that many steps.

### S3-6 / S3-18 — an installed package had no config and could not import

Two independent defects behind one symptom. `install_requires` did not name `ray[rllib]` (the env subclasses `MultiAgentEnv`), `scikit-learn` (`action_helper` imported `shuffle` at module scope) or `six` (`envs/orderbook/`, which had been resolving by accident as a transitive dependency of pandas). Separately, `config/` sits at the repo root outside the package with no `package_data`, so a built wheel carried **zero** JSON files — and because the config reads are default arguments evaluated at class-definition time, that failed at *import*, not at first use.

```
>>> import gym_continuousDoubleAuction.envs
ModuleNotFoundError: No module named 'ray.rllib'
>>> env_default('init_cash')
FileNotFoundError: Could not locate the config/ directory.
```

A `build_py` subclass now stages `config/*.json` into the package at build time — which is exactly the second location `config_dir()` already searched and never found. Nothing moves and no documented path changes; the staged copy is git-ignored and never preferred in-tree, since the repo root is checked first. `MANIFEST.in` carries the root tree into an sdist.

Note the prior remediation note in `doc/15` was wrong in a way that would have preserved the bug — it said `import ray` in the env was "entirely unused". There were two ray imports, and the one that mattered was the base class. The `Resolved since` table had also already claimed `setup.py` fixed for non-editable installs on the strength of an earlier pass that addressed neither defect; that entry is corrected.

### S3-5 — `reset(seed=...)` did nothing

Three sources of randomness — the price anchor in `reset`, order sizes in `_set_size`, the queueing order in `rand_exec_seq` — all drew from the global `np.random`. The seed reached `gymnasium.Env`, which set `self._np_random`, which nothing read.

**One correction to the original finding, because it changes how urgent this was: training runs *were* reproducible, by accident.** RLlib's `EnvRunner.__init__` calls `update_global_seed_if_necessary`, which seeds global `random` and `np.random` from `config.seed + worker_index` — and that covered all three sources. Measured: with global NumPy seeded, two runs of the same env and actions were identical; with only `reset(seed=123)`, they diverged (final price 58.0 vs 29.0). What was broken was reproducibility for anything that is *not* RLlib — the probes in `doc/16`, the generated-LOB figures, and any test wanting to pin a trajectory rather than an invariant. That last absence shows in the suite's shape.

Three things made the accidental version unreliable anyway: `run.seed` is `null` by default; the seeding happens once per worker, so episode *N* could not be reproduced without replaying 1..*N*−1; and a runner restarted by `restart_failed_env_runners` re-seeds from the same value, rewinding its stream mid-run.

All three sources now read `self.np_random`. `seed=None` deliberately does not re-seed, per the Gymnasium contract. `rand_exec_seq` honours the `seed` parameter it had accepted since it was written and nothing ever passed, and shuffles with `Generator.permutation` — so **fixing the seeding and dropping `scikit-learn` were the same edit**. That dependency was ~30 MB in every EnvRunner, used to reorder at most `num_agents` dicts.

### S3-20 — the escrow-delta path for order modification was dead

`Cash_Processor.modify_cash_transfer` moved `order_val - qoute_val` between cash and escrow, with no call sites. Deleted rather than wired up, because **it is only correct where the live path already is**. A modify is cancel-and-reprocess: `cancel_cash_transfer` returns the whole old order value to cash, `modify_order` re-runs the quote through `process_limit_order`, and the residual is re-escrowed — net movement `order_val - residual_val`. With no match, `residual_val == qoute_val` and the two are the same expression, which is why NAV conservation never told them apart:

| Modify (bid 10@100) | Escrow-delta would do | Live path does |
|---|---|---|
| → 6@100, no match | cash **+400**, hold −400 | cash **+400**, hold −400 |
| → 14@100, no match | cash **−400**, hold +400 | cash **−400**, hold +400 |
| → 10@101, hits ask@101 | cash −10, hold **+10** | cash −10, hold **−394** |
| → 10@103, hits ask@101 | cash **−30**, hold **+30** | cash **−22**, hold **−382** |

Row 3 shows the escrow leg wrong by the traded value; the cash leg coincides there only because the fill happened *at* the quoted price, so `residual_val + trade_val == qoute_val` exactly. Row 4 breaks that identity — the fill is 2 ticks better than quoted — and both legs are wrong. The function has no term for a fill, so it holds cash against quantity no longer in the book. Re-processing is not an implementation detail of modify; it is what lets a modify cross the spread, which that function assumes never happens.

## CI

A `packaging` job: build the wheel, assert it carries five config JSONs, install into a clean venv outside any checkout, construct and step an env. Every existing job installs `requirements.txt` from a checkout, so none of them can see what `pip install` gives a user — which is precisely why both halves of the packaging defect stayed green.

Already run on this branch ([32111908087](https://github.com/ChuaCheowHuan/gym-continuousDoubleAuction/actions/runs/32111908087)), both jobs green:

```
config_dir: /tmp/clean/lib/python3.12/site-packages/gym_continuousDoubleAuction/config
stepped an installed env with 5 agents
```

`config_dir` resolving *into site-packages* is the packaging fix; reaching that line at all means the imports resolved from `install_requires` and nothing else. The job costs 46s — cheaper than `test` by a factor of four — so it is not worth gating.

## Verification

`509 passed, 1 xfailed` (was 487 + 22 new tests). The 1 xfail is the pre-existing strict xfail tracking S1-1.

Two tests are load-bearing rather than incidental:

- `test_seeding.py::test_global_numpy_is_not_the_source` seeds the *global* stream to two different values and asserts a seeded episode is unchanged. It fails against the old code in the direction that hid the bug — a globally seeded process looks perfectly reproducible.
- `test_env_lifecycle.py` reads the checked-in `env_defaults.json` rather than supplying its own cash, for the reason above.

The deletion in S3-20 is constrained by the six scenarios already in `test_modify_order.py` — three cross the book and assert exact `cash` / `cash_on_hold` / `net_position`, which an escrow-shuffle cannot produce. A seventh test asserts the helper stays gone, since this is the third plausible-but-unreachable function this review turned up.

## Not addressed

Deliberately out of scope, all still open in `doc/15`: the S1/S2 items (critic receives zero gradient, no private state in the observation, do-nothing dominance) which are much larger and concern the learning problem rather than the simulator; and everything in `envs/orderbook/`, documented as off-limits to changes — which is why `six` is *declared* rather than replaced with `io.StringIO`.

One thing noticed but not touched: `scipy` has zero import sites in the package yet is declared in `requirements.txt` and the `plot` extra — the same class of mismatch as the sklearn one, in the opposite direction. Harmless, and outside what this PR set out to do.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q8i3dEvp3qxaUXgMh9gPHM)_